### PR TITLE
JackRipper branch: add lua.paths, hot reload, fetch_manifest_code_ex

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,12 +1,9 @@
 name: Build
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version (e.g. v1.0.0)"
-        required: true
-        default: ""
+  push:
+    tags:
+      - 'v*'
 
 permissions:
   contents: write
@@ -37,44 +34,24 @@ jobs:
           name: OpenSteamTool-Debug
           path: build/Debug/
 
-      - name: Generate changelog
-        id: changelog
-        shell: bash
-        run: |
-          {
-            echo 'changelog<<EOF'
-            git log -1 --pretty=format:"- %s%n%b"
-            echo ''
-            echo 'EOF'
-          } >> $GITHUB_OUTPUT
-
-      - name: Create tag
-        run: |
-          git tag ${{ github.event.inputs.version }}
-          git push origin ${{ github.event.inputs.version }}
-
       - name: Package Release
-        run: 7z a OpenSteamTool-${{ github.event.inputs.version }}-Release.zip ".\build\Release\*" -mx5
+        run: 7z a OpenSteamTool-${{ github.ref_name }}-Release.zip ".\build\Release\*" -mx5
 
       - name: Package Debug
-        run: 7z a OpenSteamTool-${{ github.event.inputs.version }}-Debug.zip ".\build\Debug\*" -mx5
+        run: 7z a OpenSteamTool-${{ github.ref_name }}-Debug.zip ".\build\Debug\*" -mx5
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ github.event.inputs.version }}
+          tag_name: ${{ github.ref_name }}
           body: |
-            ## Changes
-
-            ${{ steps.changelog.outputs.changelog }}
-
             ## Installation
 
-            Download `OpenSteamTool-${{ github.event.inputs.version }}-Release.zip` (or the `-Debug` variant if you need logging to `opensteamtool.log`).
+            Download `OpenSteamTool-${{ github.ref_name }}-Release.zip` (or the `-Debug` variant if you need logging to `opensteamtool.log`).
 
-            Extract and copy both `dwmapi.dll` and `OpenSteamTool.dll` to your Steam root directory (e.g. `C:\Program Files (x86)\Steam`).
+            Extract and copy `dwmapi.dll`, `xinput1_4.dll` and `OpenSteamTool.dll` to your Steam root directory (e.g. `C:\Program Files (x86)\Steam`).
 
-            Create a Lua config directory (for example `C:\Program Files (x86)\Steam\config\lua`) and place your Lua scripts there. **NOT** `C:\Program Files (x86)\Steam\config\stplug-in`!
+            Create Lua config directories and place your Lua scripts there. Configure the paths in `opensteamtool.toml` (see [Configuration](#configuration-optional)).
           files: |
-            OpenSteamTool-${{ github.event.inputs.version }}-Release.zip
-            OpenSteamTool-${{ github.event.inputs.version }}-Debug.zip
+            OpenSteamTool-${{ github.ref_name }}-Release.zip
+            OpenSteamTool-${{ github.ref_name }}-Debug.zip

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,23 @@
+# Build output
+build/
+.deps/
+
+# Visual Studio
+*.user
+*.suo
+*.vcxproj.user
+*.sln.user
+.vs/
+
+# IDE
+*.idea/
+*.code-workspace/
+
+# Temp files
+*.tmp
+*.log
+*.bak
+*~
+
+# DLLs (keep only source files)
+!.deps/**/*.dll

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ All function names are **case-insensitive**. `setAppTicket`, `setappticket`, `Se
 
 ### Configuration (optional)
 
-Rename `opensteamtool.example.toml` to `opensteamtool.toml` and place it in the Steam root directory (next to `steam.exe`).  
+Rename `opensteamtool.example.toml` to `opensteamtool.toml` and place it in the Steam root directory (next to `steam.exe`).
 If no config file is found, built-in defaults are used — no auto-creation.
 
 ```toml
@@ -75,13 +75,36 @@ timeout_resolve_ms = 5000
 timeout_connect_ms = 5000
 timeout_send_ms    = 10000
 timeout_recv_ms    = 10000
+
+# Additional Lua config directories (optional).
+# Files are loaded after the default <Steam>/config/lua folder.
+# The default folder is always loaded last so user files take priority.
+[lua]
+paths = []
 ```
+
+### Hot reload
+
+Lua scripts can be reloaded without restarting Steam via the IPC pipe `\\.\pipe\OpenSteamTool_Trigger`:
+
+- **FullReload** — clears all maps, reloads all lua paths, refreshes Package0, triggers Steam UI offline/online
+- **AppIdReload** — clears specified appIds from maps, reloads all lua paths, refreshes Package0, triggers Steam UI offline/online
+
+The file watcher also auto-triggers a FullReload when any `.lua` file in the watched directories changes.
 
 ### Manifest via Lua
 
-If `<Steam>/config/lua/manifest.lua` defines `fetch_manifest_code(gid)`, it
-overrides the `[manifest] url` setting.  The C++ runtime provides two Lua
-helpers:
+Two manifest code functions are supported:
+
+#### `fetch_manifest_code(gid)`
+
+Basic function that receives only the manifest GID.
+
+#### `fetch_manifest_code_ex(app_id, depot_id, gid)` *(recommended)*
+
+Extended function that receives `app_id`, `depot_id`, and `gid`. Allows constructing API endpoints that require app identification.
+
+The C++ runtime provides two Lua helpers:
 
 | Function | Signature | Returns |
 |----------|-----------|---------|

--- a/build.bat
+++ b/build.bat
@@ -15,7 +15,7 @@ if "%GENERATOR%"=="" (
     if not errorlevel 1 (
         set "GENERATOR=Ninja Multi-Config"
     ) else (
-        set "GENERATOR=Visual Studio 17 2022"
+        set "GENERATOR=Visual Studio 18 2026"
     )
 )
 if "%ARCH%"=="" set "ARCH=x64"

--- a/opensteamtool.example.toml
+++ b/opensteamtool.example.toml
@@ -11,8 +11,9 @@ level = "info"
 # Which upstream API to query for depot manifest request codes.
 #   "steamrun"  → https://manifest.steam.run/api/manifest/{gid}
 #   "wudrm"     → http://gmrc.wudrm.com/manifest/{gid}
-# If <Steam>/config/lua/manifest.lua defines fetch_manifest_code(gid),
-# that Lua function takes priority over the url setting below.
+# If <Steam>/config/lua/manifest.lua defines fetch_manifest_code(gid) or
+# fetch_manifest_code_ex(app_id, depot_id, gid), those Lua functions take
+# priority over the url setting below.
 #
 # --- manifest.lua reference ---
 # The C++ side provides http_get(url [, headers]) and
@@ -33,6 +34,15 @@ level = "info"
 #     end
 #     return nil
 # end
+#
+# -- Extended variant with app_id and depot_id:
+# function fetch_manifest_code_ex(app_id, depot_id, gid)
+#     local body, st = http_get("https://your-api.com/manifest-code/" .. app_id .. "/" .. gid)
+#     if st == 200 and body and body:match("^%d+$") then
+#         return body
+#     end
+#     return nil
+# end
 url = "steamrun"
 
 # HTTP timeouts for manifest requests (milliseconds).
@@ -44,3 +54,12 @@ timeout_resolve_ms = 5000
 timeout_connect_ms = 5000
 timeout_send_ms    = 10000
 timeout_recv_ms    = 10000
+
+# Additional Lua config directories (optional).
+# Files are loaded after the default <Steam>/config/lua folder.
+# The default folder is always loaded last so user files take priority.
+# Example — load a custom directory on another drive:
+#   [lua]
+#   paths = ["D:/my-steam-config/lua"]
+[lua]
+# paths = []

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -81,6 +81,8 @@ add_library(OpenSteamTool SHARED
     Utils/LuaConfig.cpp
     Utils/VehCommon.cpp
     Utils/WinHttp.cpp
+    Utils/FileWatcher.cpp
+    Utils/IPCTrigger.cpp
 
     # Per-category hook modules
     Hook/HookManager.cpp

--- a/src/Hook/Hooks_Manifest.cpp
+++ b/src/Hook/Hooks_Manifest.cpp
@@ -192,9 +192,19 @@ namespace Hooks_Manifest {
     }
 
     // ── resolve (single-provider, no fallback) ────────────────────
-    bool FetchManifestRequestCode(uint64_t manifestGid, uint64_t* outRequestCode) {
+    bool FetchManifestRequestCode(uint64_t manifestGid, uint64_t* outRequestCode, AppId_t AppId, AppId_t DepotId) {
         std::lock_guard<std::mutex> lock(g_ConnectionMutex);
 
+        // Try extended Lua function first (receives app_id, depot_id, gid)
+        if (AppId && DepotId && LuaConfig::HasManifestCodeFuncEx()) {
+            if (LuaConfig::CallManifestFetchCodeEx(AppId, DepotId, manifestGid, outRequestCode)) {
+                LOG_MANIFEST_INFO("Manifest gid={} resolved via fetch_manifest_code_ex", manifestGid);
+                return true;
+            }
+            LOG_MANIFEST_WARN("Manifest gid={} fetch_manifest_code_ex returned nil, trying fetch_manifest_code", manifestGid);
+        }
+
+        // Fall back to original Lua function (receives gid only)
         if (LuaConfig::HasManifestCodeFunc()) {
             if (LuaConfig::CallManifestFetchCode(manifestGid, outRequestCode)) {
                 LOG_MANIFEST_INFO("Manifest gid={} resolved via manifest.lua", manifestGid);

--- a/src/Hook/Hooks_Manifest.h
+++ b/src/Hook/Hooks_Manifest.h
@@ -8,5 +8,7 @@ namespace Hooks_Manifest {
     // Fetch a manifest request code from online providers.
     // Thread-safe — serialises access to the underlying WinHTTP connection.
     // Returns true and sets *outRequestCode on success.
-    bool FetchManifestRequestCode(uint64 manifestGid, uint64* outRequestCode);
+    // AppId and DepotId are optional; when provided, enables fetch_manifest_code_ex.
+    bool FetchManifestRequestCode(uint64_t manifestGid, uint64_t* outRequestCode,
+                                AppId_t AppId = 0, AppId_t DepotId = 0);
 }

--- a/src/Hook/Hooks_NetPacket.cpp
+++ b/src/Hook/Hooks_NetPacket.cpp
@@ -481,14 +481,15 @@ namespace Hooks_NetPacket_Manifest {
         uint64 jobId       = hdr.jobid_source();
         uint64 manifestGid = req.manifest_id();
         uint32 depotId     = req.depot_id();
+        uint32 appId       = req.has_app_id() ? req.app_id() : 0;
 
-        LOG_MANIFEST_DEBUG("GetManifestRequestCode send: depot={} gid={} jobid={}",
-                            depotId, manifestGid, jobId);
+        LOG_MANIFEST_DEBUG("GetManifestRequestCode send: depot={} gid={} jobid={} app_id={}",
+                            depotId, manifestGid, jobId, appId);
 
         auto task = std::async(std::launch::async,
-            [manifestGid]() -> uint64 {
+            [manifestGid, depotId, appId]() -> uint64 {
                 uint64 code = 0;
-                Hooks_Manifest::FetchManifestRequestCode(manifestGid, &code);
+                Hooks_Manifest::FetchManifestRequestCode(manifestGid, &code, appId, depotId);
                 return code;
             });
 

--- a/src/Hook/Hooks_Package.cpp
+++ b/src/Hook/Hooks_Package.cpp
@@ -6,22 +6,28 @@ namespace {
     using CUtlMemoryGrow_t = void* (*)(CUtlVector<uint32>* pVec, int grow_size);
     CUtlMemoryGrow_t oCUtlMemoryGrow = nullptr;
 
+    PackageInfo* g_package0 = nullptr;
+
     HOOK_FUNC(LoadPackage, bool, PackageInfo* pInfo, uint8* sha1, int32 cn, void* p4) {
         bool result = oLoadPackage(pInfo, sha1, cn, p4);
+
         if (pInfo->PackageId == 0) {
-            LOG_DEBUG("LoadPackage: package ID is 0,starting appid injection");
+            if (!g_package0) {
+                g_package0 = pInfo;
+                LOG_INFO("LoadPackage: captured Package0 pointer");
+            }
+
             std::vector<AppId_t> appIds = LuaConfig::GetAllDepotIds();
             if (!appIds.empty()) {
                 uint32 oldSize = pInfo->AppIdVec.m_Size;
                 uint32 numToAdd = static_cast<uint32>(appIds.size());
+                LOG_INFO("LoadPackage(PackageId=0): adding {} apps, oldSize={}", numToAdd, oldSize);
                 oCUtlMemoryGrow(&pInfo->AppIdVec, numToAdd);
-                LOG_DEBUG("LoadPackage: Adding {} appids", numToAdd);
                 for (uint32 i = 0; i < numToAdd; i++)
                     pInfo->AppIdVec.m_Memory.m_pMemory[oldSize + i] = appIds[i];
-            }else{
-                LOG_WARN("LoadPackage: no appids to add");
             }
         }
+
         return result;
     }
 
@@ -43,6 +49,81 @@ namespace {
 }
 
 namespace Hooks_Package {
+    void RefreshPackage0() {
+        if (!g_package0) {
+            LOG_WARN("RefreshPackage0: no Package0 pointer captured yet");
+            return;
+        }
+
+        std::vector<AppId_t> allIds = LuaConfig::GetAllDepotIds();
+        uint32 currentSize = g_package0->AppIdVec.m_Size;
+
+        std::vector<AppId_t> newIds;
+        std::vector<AppId_t> removedIds;
+
+        for (uint32 i = 0; i < currentSize; i++) {
+            AppId_t existingId = g_package0->AppIdVec.m_Memory.m_pMemory[i];
+            bool found = false;
+            for (AppId_t id : allIds) {
+                if (id == existingId) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) {
+                removedIds.push_back(existingId);
+            }
+        }
+
+        for (AppId_t id : allIds) {
+            bool found = false;
+            for (uint32 i = 0; i < currentSize; i++) {
+                if (g_package0->AppIdVec.m_Memory.m_pMemory[i] == id) {
+                    found = true;
+                    break;
+                }
+            }
+            if (!found) newIds.push_back(id);
+        }
+
+        if (!removedIds.empty()) {
+            LOG_INFO("RefreshPackage0: removing {} apps from Package0", (uint32_t)removedIds.size());
+            for (AppId_t id : removedIds) {
+                LOG_INFO("RefreshPackage0:   - removing {}", id);
+            }
+            uint32 writeIdx = 0;
+            for (uint32 i = 0; i < currentSize; i++) {
+                AppId_t id = g_package0->AppIdVec.m_Memory.m_pMemory[i];
+                bool shouldRemove = false;
+                for (AppId_t remId : removedIds) {
+                    if (remId == id) {
+                        shouldRemove = true;
+                        break;
+                    }
+                }
+                if (!shouldRemove) {
+                    g_package0->AppIdVec.m_Memory.m_pMemory[writeIdx] = id;
+                    writeIdx++;
+                }
+            }
+            g_package0->AppIdVec.m_Size = writeIdx;
+            currentSize = writeIdx;
+        }
+
+        if (!newIds.empty()) {
+            LOG_INFO("RefreshPackage0: adding {} new apps to Package0 (current size={})",
+                     (uint32_t)newIds.size(), currentSize);
+            oCUtlMemoryGrow(&g_package0->AppIdVec, static_cast<int>(newIds.size()));
+            for (size_t i = 0; i < newIds.size(); i++) {
+                g_package0->AppIdVec.m_Memory.m_pMemory[currentSize + i] = newIds[i];
+            }
+            g_package0->AppIdVec.m_Size = currentSize + static_cast<uint32>(newIds.size());
+        }
+
+        LOG_INFO("RefreshPackage0: Package0 AppIdVec now size={}",
+                 g_package0->AppIdVec.m_Size);
+    }
+
     void Install() {
         RESOLVE_D(CUtlMemoryGrow);
 
@@ -58,5 +139,6 @@ namespace Hooks_Package {
         UNINSTALL_HOOK(CheckAppOwnership);
         UNHOOK_END();
         oCUtlMemoryGrow = nullptr;
+        g_package0 = nullptr;
     }
 }

--- a/src/Hook/Hooks_Package.h
+++ b/src/Hook/Hooks_Package.h
@@ -5,4 +5,5 @@ namespace Hooks_Package {
     // user-supplied depots appear owned and accessible.
     void Install();
     void Uninstall();
+    void RefreshPackage0();
 }

--- a/src/Utils/Config.cpp
+++ b/src/Utils/Config.cpp
@@ -44,9 +44,20 @@ namespace Config {
                 }
             }
 
-            LOG_INFO("Config loaded: manifest.url={} log.level={}",
+// [lua]
+            if (auto lua = tbl["lua"].as_table()) {
+                if (auto arr = (*lua)["paths"].as_array()) {
+                    for (auto& elem : *arr) {
+                        if (auto str = elem.value<std::string>()) {
+                            luaPaths.push_back(*str);
+                        }
+                    }
+                }
+            }
+
+            LOG_INFO("Config loaded: manifest.url={} log.level={} lua.paths={}",
                      manifestUrl == ManifestUrl::Wudrm ? "wudrm" : "steamrun",
-                     [&]{
+                     [&](){
                          switch (logLevel) {
                          case LogLevel::Trace: return "trace";
                          case LogLevel::Debug: return "debug";
@@ -55,7 +66,8 @@ namespace Config {
                          case LogLevel::Error: return "error";
                          default: return "???";
                          }
-                     }());
+                     }(),
+                     (uint32_t)luaPaths.size());
 
         } catch (const toml::parse_error& e) {
             LOG_WARN("Config parse error: {}", e.what());

--- a/src/Utils/Config.h
+++ b/src/Utils/Config.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <windows.h>
 
 namespace Config {
@@ -23,5 +24,8 @@ namespace Config {
 
     // derived from configPath: <steam>/opensteamtool/
     inline std::string logDir;
+
+    // [lua]
+    inline std::vector<std::string> luaPaths;
 
 }

--- a/src/Utils/FileWatcher.cpp
+++ b/src/Utils/FileWatcher.cpp
@@ -1,0 +1,177 @@
+#include "dllmain.h"
+#include "FileWatcher.h"
+#include "LuaConfig.h"
+#include "Hook/Hooks_Package.h"
+#include "Log.h"
+#include <thread>
+#include <atomic>
+#include <shellapi.h>
+#include <vector>
+#include <string>
+
+#pragma comment(lib, "shell32.lib")
+
+namespace FileWatcher {
+    static std::atomic<bool> g_running{false};
+    static std::thread g_watcherThread;
+    static std::vector<std::string> g_watchDirs;
+
+    static const DWORD kDebounceMs = 500;
+
+    static std::string WideToString(const std::wstring& wstr) {
+        std::string result;
+        result.reserve(wstr.size());
+        for (wchar_t c : wstr) {
+            result.push_back(static_cast<char>(c));
+        }
+        return result;
+    }
+
+    static void TriggerRefresh() {
+        LOG_INFO("[FileWatcher] Detected change, triggering refresh after {}ms debounce", kDebounceMs);
+        std::this_thread::sleep_for(std::chrono::milliseconds(kDebounceMs));
+
+        LuaConfig::ParseDirectory(g_watchDirs[0], true);
+        for (size_t i = 1; i < g_watchDirs.size(); ++i) {
+            LuaConfig::ParseDirectory(g_watchDirs[i], false);
+        }
+        Hooks_Package::RefreshPackage0();
+
+        LOG_INFO("[FileWatcher] Triggering Steam UI refresh (offline)");
+        ShellExecuteA(nullptr, "open", "steam://open/gooffline", nullptr, nullptr, SW_HIDE);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        LOG_INFO("[FileWatcher] Triggering Steam UI refresh (online)");
+        ShellExecuteA(nullptr, "open", "steam://open/goonline", nullptr, nullptr, SW_HIDE);
+        LOG_INFO("[FileWatcher] Refresh completed");
+    }
+
+    static bool HasLuaChange(const char* buffer, DWORD bytesReturned) {
+        FILE_NOTIFY_INFORMATION* info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(const_cast<char*>(buffer));
+        while (info) {
+            std::wstring fname(info->FileName, info->FileNameLength / sizeof(wchar_t));
+            std::string name = WideToString(fname);
+
+            if (name.size() > 4 && name.substr(name.size() - 4) == ".lua") {
+                LOG_INFO("[FileWatcher] Lua file changed: {}", name);
+                return true;
+            }
+
+            if (info->NextEntryOffset == 0) break;
+            info = reinterpret_cast<FILE_NOTIFY_INFORMATION*>(
+                reinterpret_cast<char*>(info) + info->NextEntryOffset
+            );
+        }
+        return false;
+    }
+
+    static void WatcherThread() {
+        g_running = true;
+
+        const size_t numDirs = g_watchDirs.size();
+        std::vector<HANDLE> dirHandles(numDirs);
+        std::vector<OVERLAPPED> overlapped(numDirs);
+        std::vector<HANDLE> events(numDirs);
+        std::vector<std::vector<char>> buffers(numDirs);
+        std::vector<bool> hasChange(numDirs, false);
+
+        for (size_t i = 0; i < numDirs; ++i) {
+            events[i] = CreateEventA(nullptr, FALSE, FALSE, nullptr);
+            overlapped[i] = {};
+            overlapped[i].hEvent = events[i];
+            buffers[i].resize(65536);
+
+            dirHandles[i] = CreateFileA(
+                g_watchDirs[i].c_str(),
+                FILE_LIST_DIRECTORY,
+                FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                nullptr,
+                OPEN_EXISTING,
+                FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OVERLAPPED,
+                nullptr
+            );
+
+            if (dirHandles[i] == INVALID_HANDLE_VALUE) {
+                LOG_WARN("[FileWatcher] Failed to open directory: {} (err={})", g_watchDirs[i], GetLastError());
+                dirHandles[i] = nullptr;
+                continue;
+            }
+
+            LOG_INFO("[FileWatcher] Started watching: {}", g_watchDirs[i]);
+        }
+
+        bool allFailed = true;
+        for (auto& h : dirHandles) {
+            if (h) { allFailed = false; break; }
+        }
+        if (allFailed) {
+            LOG_WARN("[FileWatcher] No directories could be opened");
+            for (auto& e : events) if (e) CloseHandle(e);
+            return;
+        }
+
+        while (g_running) {
+            for (size_t i = 0; i < numDirs; ++i) {
+                if (!dirHandles[i]) continue;
+
+                DWORD bytesReturned = 0;
+                BOOL success = ReadDirectoryChangesW(
+                    dirHandles[i],
+                    buffers[i].data(),
+                    static_cast<DWORD>(buffers[i].size()),
+                    FALSE,
+                    FILE_NOTIFY_CHANGE_FILE_NAME |
+                    FILE_NOTIFY_CHANGE_LAST_WRITE |
+                    FILE_NOTIFY_CHANGE_CREATION,
+                    &bytesReturned,
+                    &overlapped[i],
+                    nullptr
+                );
+
+                if (!success) {
+                    LOG_WARN("[FileWatcher] ReadDirectoryChangesW failed for {}: {}", g_watchDirs[i], GetLastError());
+                }
+            }
+
+            DWORD waitResult = WaitForMultipleObjects(static_cast<DWORD>(numDirs), events.data(), FALSE, 1000);
+
+            if (!g_running) break;
+
+            if (waitResult == WAIT_TIMEOUT) continue;
+
+            if (waitResult >= WAIT_OBJECT_0 && waitResult < WAIT_OBJECT_0 + numDirs) {
+                size_t idx = waitResult - WAIT_OBJECT_0;
+                if (dirHandles[idx]) {
+                    DWORD bytesReturned = 0;
+                    if (GetOverlappedResult(dirHandles[idx], &overlapped[idx], &bytesReturned, FALSE)) {
+                        if (HasLuaChange(buffers[idx].data(), bytesReturned)) {
+                            TriggerRefresh();
+                        }
+                    }
+                    ResetEvent(events[idx]);
+                }
+            }
+        }
+
+        for (auto& h : dirHandles) if (h) CloseHandle(h);
+        for (auto& e : events) if (e) CloseHandle(e);
+        LOG_INFO("[FileWatcher] Stopped");
+    }
+
+    void Start(const std::vector<std::string>& directories) {
+        if (g_running.exchange(true)) {
+            LOG_WARN("[FileWatcher] Already running");
+            return;
+        }
+
+        g_watchDirs = directories;
+        g_watcherThread = std::thread(WatcherThread);
+    }
+
+    void Stop() {
+        if (!g_running) return;
+        g_running = false;
+        if (g_watcherThread.joinable()) {
+            g_watcherThread.join();
+        }
+    }
+}

--- a/src/Utils/FileWatcher.h
+++ b/src/Utils/FileWatcher.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <windows.h>
+#include <string>
+#include <vector>
+
+namespace FileWatcher {
+    void Start(const std::vector<std::string>& directories);
+    void Stop();
+}

--- a/src/Utils/IPCTrigger.cpp
+++ b/src/Utils/IPCTrigger.cpp
@@ -1,0 +1,154 @@
+#include "dllmain.h"
+#include "IPCTrigger.h"
+#include "LuaConfig.h"
+#include "Log.h"
+#include "Config.h"
+#include "Hook/Hooks_Package.h"
+#include <thread>
+#include <atomic>
+#include <shellapi.h>
+
+#pragma comment(lib, "shell32.lib")
+
+namespace IPCTrigger {
+    static std::atomic<bool> g_running{false};
+    static std::thread g_serverThread;
+
+    static const char* PIPE_NAME = R"(\\.\pipe\OpenSteamTool_Trigger)";
+
+    enum class Command : uint32_t {
+        FullReload = 1,
+        AppIdReload = 2,
+        Shutdown = 3,
+    };
+
+    struct Packet {
+        Command cmd;
+        uint32_t payloadSize;
+    };
+
+    static void TriggerSteamUIRefresh() {
+        LOG_INFO("[IPCTrigger] Triggering Steam UI refresh (offline)");
+        ShellExecuteA(nullptr, "open", "steam://open/gooffline", nullptr, nullptr, SW_HIDE);
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+        LOG_INFO("[IPCTrigger] Triggering Steam UI refresh (online)");
+        ShellExecuteA(nullptr, "open", "steam://open/goonline", nullptr, nullptr, SW_HIDE);
+    }
+
+    static void ServerThread() {
+        while (g_running) {
+            HANDLE pipe = CreateNamedPipeA(
+                PIPE_NAME,
+                PIPE_ACCESS_DUPLEX,
+                PIPE_TYPE_MESSAGE | PIPE_READMODE_MESSAGE | PIPE_WAIT,
+                1,
+                4096,
+                4096,
+                1000,
+                nullptr
+            );
+
+            if (!pipe || pipe == INVALID_HANDLE_VALUE) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(500));
+                continue;
+            }
+
+            BOOL connected = ConnectNamedPipe(pipe, nullptr) ? TRUE : (GetLastError() == ERROR_PIPE_CONNECTED);
+            if (!connected) {
+                CloseHandle(pipe);
+                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                continue;
+            }
+
+            Packet packet{};
+            DWORD bytesRead = 0;
+
+            if (ReadFile(pipe, &packet, sizeof(packet), &bytesRead, nullptr)) {
+                if (packet.cmd == Command::FullReload) {
+                    LOG_INFO("[IPCTrigger] FullReload command received");
+                    if (!Config::luaPaths.empty()) {
+                        LuaConfig::ParseDirectory(Config::luaPaths[0], true);
+                        for (size_t i = 1; i < Config::luaPaths.size(); ++i) {
+                            LuaConfig::ParseDirectory(Config::luaPaths[i], false);
+                        }
+                    } else {
+                        LuaConfig::ParseDirectory(std::string(LuaDir), true);
+                    }
+                    Hooks_Package::RefreshPackage0();
+                    TriggerSteamUIRefresh();
+                    LOG_INFO("[IPCTrigger] FullReload completed");
+                }
+                else if (packet.cmd == Command::AppIdReload) {
+                    std::vector<AppId_t> appIds;
+                    if (packet.payloadSize > 0) {
+                        std::vector<uint8_t> buffer(packet.payloadSize);
+                        DWORD bytesReadPayload = 0;
+                        if (ReadFile(pipe, buffer.data(), packet.payloadSize, &bytesReadPayload, nullptr)) {
+                            const uint32_t* data = reinterpret_cast<const uint32_t*>(buffer.data());
+                            uint32_t count = packet.payloadSize / sizeof(uint32_t);
+                            appIds.assign(data, data + count);
+                        }
+                    }
+                    LOG_INFO("[IPCTrigger] AppIdReload: {} ids", (uint32_t)appIds.size());
+                    for (AppId_t appId : appIds) {
+                        LOG_INFO("[IPCTrigger]   - {}", appId);
+                    }
+                    LuaConfig::RefreshAppIds(appIds);
+                    Hooks_Package::RefreshPackage0();
+                    TriggerSteamUIRefresh();
+                    LOG_INFO("[IPCTrigger] AppIdReload completed");
+                }
+                else if (packet.cmd == Command::Shutdown) {
+                    LOG_INFO("[IPCTrigger] Shutdown command received");
+                    g_running = false;
+                }
+            }
+
+            FlushFileBuffers(pipe);
+            DisconnectNamedPipe(pipe);
+            CloseHandle(pipe);
+        }
+
+        LOG_INFO("[IPCTrigger] Server thread exiting");
+    }
+
+    bool StartServer() {
+        if (g_running.exchange(true)) {
+            LOG_WARN("[IPCTrigger] Server already running");
+            return false;
+        }
+
+        g_serverThread = std::thread(ServerThread);
+        LOG_INFO("[IPCTrigger] Server started on {}", PIPE_NAME);
+        return true;
+    }
+
+    void StopServer() {
+        g_running = false;
+        if (g_serverThread.joinable()) {
+            g_serverThread.join();
+        }
+        LOG_INFO("[IPCTrigger] Server stopped");
+    }
+
+    void TriggerFullReload() {
+        LOG_INFO("[IPCTrigger] TriggerFullReload called");
+        if (!Config::luaPaths.empty()) {
+            LuaConfig::ParseDirectory(Config::luaPaths[0], true);
+            for (size_t i = 1; i < Config::luaPaths.size(); ++i) {
+                LuaConfig::ParseDirectory(Config::luaPaths[i], false);
+            }
+        } else {
+            LuaConfig::ParseDirectory(std::string(LuaDir), true);
+        }
+        Hooks_Package::RefreshPackage0();
+        TriggerSteamUIRefresh();
+    }
+
+    void TriggerAppIdReload(const std::vector<AppId_t>& appIds) {
+        LOG_INFO("[IPCTrigger] TriggerAppIdReload called for {} appIds", (uint32_t)appIds.size());
+        LuaConfig::RefreshAppIds(appIds);
+        Hooks_Package::RefreshPackage0();
+        TriggerSteamUIRefresh();
+    }
+}

--- a/src/Utils/IPCTrigger.h
+++ b/src/Utils/IPCTrigger.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <vector>
+
+namespace IPCTrigger {
+    bool StartServer();
+    void StopServer();
+    void TriggerFullReload();
+    void TriggerAppIdReload(const std::vector<AppId_t>& appIds);
+}

--- a/src/Utils/LuaConfig.cpp
+++ b/src/Utils/LuaConfig.cpp
@@ -14,6 +14,7 @@ extern "C" {
 namespace LuaConfig{
     static lua_State* g_lua_state = nullptr;
     static bool g_hasManifestCodeFunc = false;
+    static bool g_hasManifestCodeFuncEx = false;
     std::unordered_map<AppId_t, std::string>DepotKeySet{};
     std::unordered_map<AppId_t, uint64_t>AccessTokenSet{};
     std::unordered_set<AppId_t> PinnedApps{};
@@ -424,6 +425,82 @@ namespace LuaConfig{
       return ManifestOverrides;
     }
 
+    void ClearAllMaps() {
+        DepotKeySet.clear();
+        AccessTokenSet.clear();
+        PinnedApps.clear();
+        ManifestOverrides.clear();
+        StatSteamIdSet.clear();
+        OwnedAppIdSet.clear();
+        g_hasManifestCodeFunc = false;
+        g_hasManifestCodeFuncEx = false;
+        LOG_INFO("Cleared all LuaConfig maps");
+    }
+
+    void ClearAppId(AppId_t appId) {
+        DepotKeySet.erase(appId);
+        AccessTokenSet.erase(appId);
+        PinnedApps.erase(appId);
+        StatSteamIdSet.erase(appId);
+        OwnedAppIdSet.erase(appId);
+        ManifestOverrides.erase(appId);
+        LOG_INFO("Cleared appId {} from all maps", appId);
+    }
+
+    void RefreshAppIds(const std::vector<AppId_t>& appIds) {
+        for (AppId_t appId : appIds) {
+            ClearAppId(appId);
+        }
+        if (!Initialize()) return;
+
+        std::error_code ec;
+        if (!std::filesystem::exists(LuaDir, ec))
+            std::filesystem::create_directories(LuaDir, ec);
+        if (!std::filesystem::exists(LuaDir, ec) || !std::filesystem::is_directory(LuaDir, ec))
+            return;
+
+        for (const auto& entry : std::filesystem::directory_iterator(LuaDir, ec)) {
+            if (ec) break;
+            if (!entry.is_regular_file()) continue;
+            const auto& path = entry.path();
+            if (path.extension() != ".lua") continue;
+
+            std::ifstream file(path);
+            if (!file) continue;
+
+            std::string chunk, line;
+            int lineNo = 0;
+            while (std::getline(file, line)) {
+                ++lineNo;
+                if (!chunk.empty()) chunk += '\n';
+                chunk += line;
+
+                lua_settop(g_lua_state, 0);
+                int rc = luaL_loadstring(g_lua_state, chunk.c_str());
+                if (rc == LUA_OK) {
+                    if (lua_pcall(g_lua_state, 0, 0, 0) != LUA_OK) {
+                        const char* err = lua_tostring(g_lua_state, -1);
+                        LOG_WARN("{}:{}: {}", path.filename().string(), lineNo,
+                                 err ? err : "unknown");
+                    }
+                    chunk.clear();
+                } else if (rc == LUA_ERRSYNTAX) {
+                    lua_pop(g_lua_state, 1);
+                } else {
+                    const char* err = lua_tostring(g_lua_state, -1);
+                    LOG_WARN("{}:{}: {}", path.filename().string(), lineNo, err ? err : "unknown");
+                    lua_pop(g_lua_state, 1);
+                    chunk.clear();
+                }
+            }
+            if (!chunk.empty()) {
+                LOG_WARN("{}: incomplete statement at end of file", path.filename().string());
+            }
+        }
+
+        LOG_INFO("RefreshAppIds completed, {} depots loaded", (uint32_t)DepotKeySet.size());
+    }
+
     bool HasManifestCodeFunc() {
         return g_hasManifestCodeFunc;
     }
@@ -474,8 +551,58 @@ namespace LuaConfig{
         return true;
     }
 
+    bool HasManifestCodeFuncEx() {
+        return g_hasManifestCodeFuncEx;
+    }
+
+    bool CallManifestFetchCodeEx(uint64_t app_id, uint64_t depot_id, uint64_t gid, uint64_t* outCode) {
+        if (!g_hasManifestCodeFuncEx || !g_lua_state)
+            return false;
+
+        lua_getglobal(g_lua_state, "fetch_manifest_code_ex");
+        lua_pushinteger(g_lua_state, static_cast<lua_Integer>(app_id));
+        lua_pushinteger(g_lua_state, static_cast<lua_Integer>(depot_id));
+        lua_pushinteger(g_lua_state, static_cast<lua_Integer>(gid));
+
+        if (lua_pcall(g_lua_state, 3, 1, 0) != LUA_OK) {
+            LOG_MANIFEST_WARN("fetch_manifest_code_ex({}, {}, {}) error: {}", app_id, depot_id, gid,
+                             lua_tostring(g_lua_state, -1));
+            lua_pop(g_lua_state, 1);
+            return false;
+        }
+
+        if (lua_isnil(g_lua_state, -1)) {
+            LOG_MANIFEST_WARN("fetch_manifest_code_ex({}, {}, {}) returned nil", app_id, depot_id, gid);
+            lua_pop(g_lua_state, 1);
+            return false;
+        }
+
+        if (lua_isinteger(g_lua_state, -1)) {
+            *outCode = static_cast<uint64_t>(lua_tointeger(g_lua_state, -1));
+        } else if (lua_isstring(g_lua_state, -1)) {
+            const char* s = lua_tostring(g_lua_state, -1);
+            if (!std::all_of(s, s + strlen(s), ::isdigit)) {
+                LOG_MANIFEST_WARN("fetch_manifest_code_ex({}, {}, {}) returned non-numeric string '{}'",
+                                 app_id, depot_id, gid, s);
+                lua_pop(g_lua_state, 1);
+                return false;
+            }
+            *outCode = std::stoull(s);
+        } else {
+            LOG_MANIFEST_WARN("fetch_manifest_code_ex({}, {}, {}) unexpected type (expected digit-string)",
+                             app_id, depot_id, gid);
+            lua_pop(g_lua_state, 1);
+            return false;
+        }
+
+        LOG_MANIFEST_INFO("fetch_manifest_code_ex({}, {}, {}) = {}", app_id, depot_id, gid, *outCode);
+        lua_pop(g_lua_state, 1);
+        return true;
+    }
+
     // ── directory scanner ────────────────────────────────────────
-    void ParseDirectory(const std::string& directory) {
+    void ParseDirectory(const std::string& directory, bool clearFirst) {
+        if (clearFirst) ClearAllMaps();
         if (!Initialize()) return;
 
         std::error_code ec;
@@ -538,6 +665,14 @@ namespace LuaConfig{
         if (lua_isfunction(g_lua_state, -1)) {
             g_hasManifestCodeFunc = true;
             LOG_INFO("manifest.lua: fetch_manifest_code found");
+        }
+        lua_pop(g_lua_state, 1);
+
+        g_hasManifestCodeFuncEx = false;
+        lua_getglobal(g_lua_state, "fetch_manifest_code_ex");
+        if (lua_isfunction(g_lua_state, -1)) {
+            g_hasManifestCodeFuncEx = true;
+            LOG_INFO("manifest.lua: fetch_manifest_code_ex found");
         }
         lua_pop(g_lua_state, 1);
 

--- a/src/Utils/LuaConfig.h
+++ b/src/Utils/LuaConfig.h
@@ -2,6 +2,9 @@
 #define LUACONFIG_H
 
 #include <cstdint>
+#include <unordered_map>
+#include <string>
+#include <vector>
 
 namespace LuaConfig{
     bool HasDepot(AppId_t appId);
@@ -16,17 +19,19 @@ namespace LuaConfig{
           uint64_t gid;
           uint64_t size;
     };
-    // depotId → {gid, size}
     const std::unordered_map<uint64_t, ManifestOverride>& GetManifestOverrides();
 
-    void ParseDirectory(const std::string& directory);
+    void ParseDirectory(const std::string& directory, bool clearFirst = false);
 
-    // manifest.lua — fetch_manifest_code(gid) -> uint64 | nil
-    // Returns true if manifest.lua defined a fetch_manifest_code function.
+    void RefreshAppIds(const std::vector<AppId_t>& appIds);
+    void ClearAppId(AppId_t appId);
+    void ClearAllMaps();
+
     bool HasManifestCodeFunc();
-    // Call the Lua fetch_manifest_code(gid). Returns false if no function or
-    // it returned nil.
     bool CallManifestFetchCode(uint64_t gid, uint64_t* outCode);
+
+    bool HasManifestCodeFuncEx();
+    bool CallManifestFetchCodeEx(uint64_t app_id, uint64_t depot_id, uint64_t gid, uint64_t* outCode);
 }
 
 #endif // LUACONFIG_H

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -1,5 +1,7 @@
 #include "dllmain.h"
 #include "Hook/HookManager.h"
+#include "Utils/FileWatcher.h"
+#include "Utils/IPCTrigger.h"
 
 // Load diversion.dll and prepare key runtime paths.
 bool LoadDiversion()
@@ -44,7 +46,16 @@ static DWORD WINAPI InitThread(LPVOID param) {
 
     Config::Load(ConfigPath);
     Log::InitModules();
-    LuaConfig::ParseDirectory(std::string(LuaDir));
+
+    std::vector<std::string> watchDirs = Config::luaPaths;
+    watchDirs.push_back(std::string(LuaDir));
+    for (size_t i = 0; i < watchDirs.size(); ++i) {
+        LuaConfig::ParseDirectory(watchDirs[i], i == 0);
+    }
+
+    FileWatcher::Start(watchDirs);
+    IPCTrigger::StartServer();
+
     SteamUI::CoreHook();
     SteamClient::CoreHook();
     LOG_INFO("OpenSteamTool init complete");
@@ -63,6 +74,8 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, PVOID pvReserved)
     }
     else if (dwReason == DLL_PROCESS_DETACH)
     {
+        FileWatcher::Stop();
+        IPCTrigger::StopServer();
         SteamUI::CoreUnhook();
         SteamClient::CoreUnhook();
     }


### PR DESCRIPTION
Features ported from OpenSteamTool-Copy:
- [lua] paths config: load additional Lua directories from toml
- FileWatcher: auto-reload on .lua file changes (ReadDirectoryChangesW)
- IPCTrigger: named pipe server for FullReload/AppIdReload/Shutdown commands
- RefreshPackage0: update Package0 app list on reload
- fetch_manifest_code_ex: extended manifest code function (app_id, depot_id, gid)
- ClearAllMaps, ClearAppId, RefreshAppIds in LuaConfig

Also includes:
- .gitignore (excludes build/, .deps/, VS/IDE artifacts)
- .github/workflows/main.yml for releases on tag push
- build.bat: use Visual Studio 18 2026 generator
- opensteamtool.example.toml: updated with [lua] paths section
- README.md: updated with hot reload and manifest documentation
- Hooks_Manifest: extended FetchManifestRequestCode with AppId/DepotId params
- Hooks_NetPacket: passes app_id from protobuf to FetchManifestRequestCode