### PR TITLE
Fix controller support and overlay identity for -onlinefix games

### DIFF
--- a/src/Hook/Hooks_Misc.cpp
+++ b/src/Hook/Hooks_Misc.cpp
@@ -97,6 +97,45 @@ namespace {
 
         return EXCEPTION_CONTINUE_SEARCH;
     }
+
+    // ── SteamController_OptedInMask ──────────────────────────────────────────
+    // Called by CUser_BuildSpawnEnvBlock with pGameID's appid to
+    // compute EnableConfiguratorSupport and the SDL_* env vars.
+    // With 480 the spawned game inherits Spacewar's Steam Input
+    // opt-in and gameoverlayrenderer hijacks the XInput stream.
+    HOOK_FUNC(OptedInMask, __int64,
+              void* pThis, unsigned int appId)
+    {
+        if (appId == kOnlineFixAppId && g_OnlineFixRealAppId) {
+            LOG_MISC_INFO("OptedInMask: appid {} -> {}",
+                          appId, g_OnlineFixRealAppId);
+            return oOptedInMask(pThis, g_OnlineFixRealAppId);
+        }
+        return oOptedInMask(pThis, appId);
+    }
+
+    // ── CUser_BuildSpawnEnvBlock ─────────────────────────────────────────────
+    // pOverlayCGameID drives SteamOverlayGameId, which the in-game
+    // overlay reads for screenshot tags, community URLs, and asset
+    // selection.  pCGameID drives SteamGameId / SteamAppId; leave it
+    // at 480 so the in-game ownership bypass holds.
+    HOOK_FUNC(BuildSpawnEnvBlock, __int64,
+              void* pThis, uint64_t* pCGameID, void* a3, void* env,
+              uint64_t* pOverlayCGameID, void* a6, int a7,
+              void* a8, void* a9, unsigned int a10, char a11)
+    {
+        if (g_OnlineFixRealAppId && pOverlayCGameID
+            && (*pOverlayCGameID & 0xFFFFFF) == kOnlineFixAppId) {
+            uint64_t prev = *pOverlayCGameID;
+            *pOverlayCGameID = (prev & ~static_cast<uint64_t>(0xFFFFFF))
+                             | g_OnlineFixRealAppId;
+            LOG_MISC_INFO("BuildSpawnEnvBlock: overlay CGameID {:#x} -> {:#x}",
+                          prev, *pOverlayCGameID);
+        }
+        return oBuildSpawnEnvBlock(pThis, pCGameID, a3, env,
+                                    pOverlayCGameID, a6, a7,
+                                    a8, a9, a10, a11);
+    }
 }
 
 namespace Hooks_Misc {
@@ -113,9 +152,19 @@ namespace Hooks_Misc {
 
         if (!g_captures.empty() || g_spawnProcessTarget)
             g_vehHandle = AddVectoredExceptionHandler(1, VehHandler);
+
+        HOOK_BEGIN();
+        INSTALL_HOOK_D(BuildSpawnEnvBlock);
+        INSTALL_HOOK_D(OptedInMask);
+        HOOK_END();
     }
 
     void Uninstall() {
+        UNHOOK_BEGIN();
+        UNINSTALL_HOOK(BuildSpawnEnvBlock);
+        UNINSTALL_HOOK(OptedInMask);
+        UNHOOK_END();
+
         if (g_vehHandle) {
             RemoveVectoredExceptionHandler(g_vehHandle);
             g_vehHandle = nullptr;

--- a/src/Hook/Patterns.h
+++ b/src/Hook/Patterns.h
@@ -29,6 +29,11 @@ inline const Signature BuildDepotDependencySigs[] = {
     {"1778281814", "48 8B C4 4C 89 48 20 89 50 10 48 89 48 08 55 ?? 48 8D"},  // stable
 };
 
+inline const Signature BuildSpawnEnvBlockSigs[] = {
+    {"1779155395", "4C 89 4C 24 ?? 4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 55 53 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05"},  // beta
+    {"1778281814", "48 89 5C 24 ?? 4C 89 44 24 ?? 48 89 54 24 ?? 48 89 4C 24 ?? 55 56 57 41 54 41 55 41 56 41 57 48 8D AC 24 ?? ?? ?? ?? 48 81 EC ?? ?? ?? ?? 48 8B 05"},  // stable
+};
+
 inline const Signature CUtlBufferEnsureCapacitySigs[] = {
     {"1778803745", "48 89 5C 24 08 57 48 83 EC 30 48 8B D9 8D"},  // beta
     {"1778281814", "48 89 5C 24 ?? 57 48 83 EC ?? 0F B6 41 ?? 8D 7A"},  // stable
@@ -92,6 +97,11 @@ inline const Signature LoadPackageSigs[] = {
 inline const Signature MarkLicenseAsChangedSigs[] = {
     {"1778803745", "48 89 5C 24 20 89 54 24 10 55 56 57 48 83 EC 20"},  // beta
     {"1778281814", "89 54 24 ?? 53 55 56 57 41 56 48 83 EC"},  // stable
+};
+
+inline const Signature OptedInMaskSigs[] = {
+    {"1779155395", "89 54 24 ?? 55 53 56 57 41 54 41 55 48 8D AC 24"},  // beta
+    {"1778281814", "89 54 24 ?? 55 53 56 41 55 41 56 41 57"},  // stable
 };
 
 inline const Signature PchMsgNameFromEMsgSigs[] = {


### PR DESCRIPTION
This fixes two side effects of the 480 rewrite for `-onlinefix`that the existing hooks didn't account for:

- `CSteamController::OptedInMask(480)` returns Spacewar's (empty) mask, so the game sees no controller and forcing Steam Input from the per-game properties has no effect.
- `CUser::BuildSpawnEnvBlock` writes 480 into `SteamOverlayGameId`, so the overlay tags screenshots as Spacewar and "View Community Hub" opens homepage instead.

The bug (#39) is fixed by using two hooks in `Hooks_Misc`, gated on `g_OnlineFixRealAppId`:

- `OptedInMask`: swap the queried appid back to the real one before delegating.
- `BuildSpawnEnvBlock`: rewrite the low 24 bits of `*pOverlayCGameID` from 480 to the real appid before delegating. `pCGameID` is left at 480 so the lobby/matchmaking redirection still holds.

`Patterns.h` gets entries for both functions on the current beta (1779155395)+ stable (1778281814).

**Tested**

| Scenario | Result |
|---|---|
| Windblown with `-onlinefix`, controller plugged in | Controller works in-game |
| Same, with "Force Steam Input" toggled per-game | Steam Input takes effect |
| Overlay screenshot in an `-onlinefix` game | Tagged as the real game |
| Overlay "View Community Hub" in an `-onlinefix` game | Opens the real game's hub |
| Non-onlinefix game launched after | Hooks no-op, no regression |
