### PR TITLE
add feature portable support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -84,6 +84,7 @@ add_library(OpenSteamTool SHARED
     Utils/VehCommon.cpp
     Utils/WinHttp.cpp
     Utils/FileWatcher.cpp
+    Utils/DllDirectory.cpp
 
     # Per-category hook modules
     Hook/HookManager.cpp

--- a/src/Utils/DllDirectory.cpp
+++ b/src/Utils/DllDirectory.cpp
@@ -1,0 +1,19 @@
+#include "DllDirectory.h"
+#include <windows.h>
+
+namespace Utils {
+
+    std::filesystem::path GetDllDirectory() {
+        HMODULE hSelf = nullptr;
+        GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS |
+            GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCSTR>(&GetDllDirectory),
+            &hSelf
+        );
+        char dllPath[MAX_PATH] = { 0 };
+        GetModuleFileNameA(hSelf, dllPath, MAX_PATH);
+        return std::filesystem::path(dllPath).parent_path();
+    }
+
+}

--- a/src/Utils/DllDirectory.h
+++ b/src/Utils/DllDirectory.h
@@ -1,0 +1,7 @@
+#pragma once
+#include <filesystem>
+
+namespace Utils {
+    // Returns the directory where the current DLL is located.
+    std::filesystem::path GetDllDirectory();
+}

--- a/src/Utils/PatternLoader.cpp
+++ b/src/Utils/PatternLoader.cpp
@@ -3,6 +3,7 @@
 #include "Hash.h"
 #include "Log.h"
 #include "WinHttp.h"
+#include "DllDirectory.h"
 
 #include <chrono>
 #include <filesystem>
@@ -184,15 +185,15 @@ static void ShowDownloadFailedPopup(const std::string& dllName,
             "  1. Wait for the next signature update (usually within hours of "
             "a new Steam build), then restart Steam.\n"
             "  2. Drop a matching TOML at:\n"
-            "       <Steam>\\opensteamtool\\pattern\\" + ghSubdir + "\\" + sha256 + ".toml\n"
+            "       <DLL>\\opensteamtool\\pattern\\" + ghSubdir + "\\" + sha256 + ".toml\n"
             "  3. Check upstream:\n"
             "       https://github.com/OpenSteam001/steam-monitor/tree/pattern/" + ghSubdir + "\n"
             "  4. Report this hash so it gets prioritized:\n"
             "       https://github.com/OpenSteam001/OpenSteamTool/issues";
         MessageBoxA(nullptr, msg.c_str(),
-                    "OpenSteamTool - Unsupported Steam Version",
-                    MB_OK | MB_ICONWARNING | MB_TOPMOST);
-    }).detach();
+            "OpenSteamTool - Unsupported Steam Version",
+            MB_OK | MB_ICONWARNING | MB_TOPMOST);
+        }).detach();
 }
 
 } // namespace
@@ -223,10 +224,10 @@ bool Load(HMODULE module, const std::string& dllPath, const std::string& ghSubdi
     LOG_INFO("PatternLoader: {} sha256 = {} ({} ms)", ghSubdir, sha256, hashMs);
 
     // 2. Build local cache path and make sure the directory exists.
-    //    Cache lives at: <steam>/opensteamtool/pattern/<subdir>/<sha256>.toml
+    //    Cache lives at: <DLL>/opensteamtool/pattern/<subdir>/<sha256>.toml
     //    dllPath is always inside the Steam root directory.
-    fs::path steamRoot = fs::path(dllPath).parent_path();
-    fs::path cacheDir  = steamRoot / "opensteamtool" / "pattern" / ghSubdir;
+    fs::path dllRoot = Utils::GetDllDirectory();
+    fs::path cacheDir = dllRoot / "opensteamtool" / "pattern" / ghSubdir;
     fs::path cachePath = cacheDir / (sha256 + ".toml");
 
     std::error_code mkdirEc;

--- a/src/Utils/Utils.h
+++ b/src/Utils/Utils.h
@@ -1,0 +1,12 @@
+#pragma once
+#include <windows.h>
+#include <filesystem>
+#include <string>
+
+namespace Utils {
+    inline std::filesystem::path GetDllDirectory() {
+        char dllPath[MAX_PATH];
+        GetModuleFileNameA(g_hSelfModule, dllPath, MAX_PATH);
+        return std::filesystem::path(dllPath).parent_path();
+    }
+}

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -2,6 +2,7 @@
 #include "Hook/HookManager.h"
 #include "Utils/FileWatcher.h"
 #include "Utils/PatternLoader.h"
+#include "Utils/DllDirectory.h"
 
 // prepare key runtime paths.
 bool InitializeSteamComponents()
@@ -9,11 +10,12 @@ bool InitializeSteamComponents()
     if (!GetCurrentDirectoryA(MAX_PATH, SteamInstallPath)) {
         return false;
     }
-    sprintf_s(SteamclientPath, MAX_PATH, "%s\\steamclient64.dll",  SteamInstallPath);
-    sprintf_s(SteamUIPath,     MAX_PATH, "%s\\steamui.dll",        SteamInstallPath);
-    sprintf_s(DiversionPath,   MAX_PATH, "%s\\bin\\diversion.dll", SteamInstallPath);
-    sprintf_s(LuaDir,          MAX_PATH, "%s\\config\\lua",        SteamInstallPath);
-    sprintf_s(ConfigPath,      MAX_PATH, "%s\\opensteamtool.toml", SteamInstallPath);
+    sprintf_s(SteamclientPath, MAX_PATH, "%s\\steamclient64.dll", SteamInstallPath);
+    sprintf_s(SteamUIPath, MAX_PATH, "%s\\steamui.dll", SteamInstallPath);
+    sprintf_s(DiversionPath, MAX_PATH, "%s\\bin\\diversion.dll", SteamInstallPath);
+    sprintf_s(DllDir, MAX_PATH, "%s", Utils::GetDllDirectory().string().c_str());
+    sprintf_s(LuaDir, MAX_PATH, "%s\\config\\lua", DllDir);
+    sprintf_s(ConfigPath, MAX_PATH, "%s\\opensteamtool.toml", DllDir);
     
     client_hModule = LoadLibraryA(SteamclientPath);
     if (!client_hModule) {

--- a/src/dllmain.h
+++ b/src/dllmain.h
@@ -33,6 +33,7 @@ inline char SteamUIPath[MAX_PATH]      = {};
 inline char DiversionPath[MAX_PATH]    = {};
 inline char LuaDir[MAX_PATH]           = {};
 inline char ConfigPath[MAX_PATH]       = {};
+inline char DllDir[MAX_PATH]           = {};
 
 // The fake AppId used by -onlinefix (SpaceWar).
 constexpr AppId_t kOnlineFixAppId = 480;


### PR DESCRIPTION
Added a portable mode for anyone who prefers keeping things portable so it doesn't mess up or pollute the Steam folder.

Just a heads up: the injector part is still missing (see #38). To be honest, that injector was fully made with AI, so you can probably do a way better job with it than I did lol. But overall, everything else is working perfectly fine on my end.

Fixes OpenSteam001/OpenSteamTool#38