### PR TITLE
Fix Denuvo ticket SteamID offset (Token Error fix)

### DIFF
--- a/src/Utils/Tickets/AppTicket.cpp
+++ b/src/Utils/Tickets/AppTicket.cpp
@@ -162,8 +162,9 @@ namespace AppTicket {
         // ticket so spoofed responses match what the DRM layer expects.
         // Layout: ticket bytes start with [uint32 Size][uint32 Version][uint64 SteamID][...].
         std::vector<uint8_t> ticket = GetAppOwnershipTicketFromCredentialStore(appId);
-        if (ticket.size() >= kSteamIdTicketMinimumSize) {
-            const uint64_t steamID = reinterpret_cast<const uint64_t*>(ticket.data())[1];
+        if (ticket.size() >= 20) {
+            uint64_t steamID = 0;
+            std::memcpy(&steamID, ticket.data() + 12, sizeof(steamID));
             LOG_DEBUG("GetSpoofSteamID for AppId {}: -> 0x{:X}({})", appId, steamID, steamID);
             return steamID;
         }


### PR DESCRIPTION
Newer Denuvo games use a different eTicket format where the SteamID is located at offset 12 instead of 8. The previous code was reading garbage data, causing the Denuvo token generation to fail completely. This PR updates GetSpoofSteamID to correctly read the SteamID from offset 12, fixing the token error for these titles.