### PR TITLE
fix: force DLC ownership for family shared games in CheckAppOwnership

### DIFF
--- a/src/Hook/Hooks_Package.cpp
+++ b/src/Hook/Hooks_Package.cpp
@@ -97,7 +97,6 @@ namespace {
         bool result = oCheckAppOwnership(pObj, appId, pOwn);
         TryInitFakeLicenseOnce();
 
-        // LOG_PACKAGE_TRACE("CheckAppOwnership: AppId={} result={} {}", appId, result, pOwn->DebugString());
         if (LuaConfig::HasDepot(appId,false)) {
             if (result && pOwn->ExistInPackageNums > 1) {
                 // Actually owned — record so HasDepot excludes it going forward
@@ -106,6 +105,7 @@ namespace {
             } else {
                 pOwn->PackageId    = kInjectedPackageId;
                 pOwn->ReleaseState = EAppReleaseState::Released;
+                pOwn->bOwnsLicense = true; //This forces DLCs on steam family shared games that u dont own when adding their appid via .lua
                 // Setting this free flag to false will hide it from the library UI.
                 pOwn->bFreeLicense = false;
                 return true;


### PR DESCRIPTION
Fix: unlock depot-less DLCs on family-shared base games

CheckAppOwnership forced the return value for lua DLCs but left
pOwn->bOwnsLicense=false. On an owned base the fake package-0 license
makes Steam report owns=true anyway, but on a borrowed (family-shared)
base Steam returns owns=false for depot-less DLCs, so callers reading
bOwnsLicense kept them locked. Set bOwnsLicense=true on the forced DLC
only; the base game's struct is untouched, preserving family-share
playtime/achievements/workshop.


https://github.com/user-attachments/assets/57d04603-de05-4039-baed-cefa3daf8508

