### PR TITLE
Added CloudRedirect support (Cloud saves/luas/achivements/etc)

### DIFF
--- a/opensteamtool.example.toml
+++ b/opensteamtool.example.toml
@@ -78,6 +78,20 @@ enabled = false
 # library_x64 = "OpenSteamTool.GameHook.x64.dll"
 # library_x86 = "OpenSteamTool.GameHook.x86.dll"
 
+[cloud]
+# Optional Steam Cloud save redirection for unlocked ("lua") games, powered by
+# CloudRedirect (https://github.com/Selectively11/CloudRedirect).
+# When enabled, OpenSteamTool loads cloud_redirect.dll inside Steam, registers
+# every addappid() game as a redirected app, and routes their Steam Cloud RPCs
+# through CloudRedirect's cloud-save engine.
+#
+# Provider sign-in (Google Drive / OneDrive / local folder) is still done through
+# CloudRedirect's own companion app — OpenSteamTool only hosts the DLL.
+enabled = false
+# Path to cloud_redirect.dll. Absolute, or relative to the Steam root directory.
+# Defaults to "<Steam>/cloud_redirect.dll" when unset.
+# library = "cloud_redirect.dll"
+
 [remote]
 # Optional metadata mirror. Leave unset to use GitHub with jsDelivr fallback.
 # A custom mirror replaces the built-in remote sources and must include all

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -107,6 +107,7 @@ add_library(OpenSteamTool SHARED
     Utils/Config/ConfigFileWatcher.cpp
     Utils/Config/LuaConfig.cpp
     Utils/Config/LuaFileWatcher.cpp
+    Utils/CloudRedirect/CloudRedirectHost.cpp
     Utils/HookSupport/VehCommon.cpp
     Utils/Logging/Log.cpp
     Utils/SteamMetadata/IPCLoader.cpp

--- a/src/Hook/Hooks_NetPacket.cpp
+++ b/src/Hook/Hooks_NetPacket.cpp
@@ -5,9 +5,14 @@
 #include "dllmain.h"
 #include "Utils/Tickets/AppTicket.h"
 #include "Utils/Support/FnvHash.h"
+#include "Utils/CloudRedirect/CloudRedirectHost.h"
 #include <chrono>
+#include <cstring>
+#include <deque>
 #include <future>
+#include <mutex>
 #include <unordered_map>
+#include <vector>
 
 #include "steam_messages.pb.h"
 
@@ -37,6 +42,7 @@ namespace {
     uint8  g_SendNewBody[kMaxBodySize];
     uint32 g_cbSendNewBody = 0;
     bool   g_NeedReplaceSend = false;
+    bool   g_SuppressSend    = false;   // drop the outbound frame entirely (cloud RPC answered locally)
     uint8  g_SendPacketPool[kPacketPoolSize][kMaxPacketSize];
     int    g_SendPacketPoolIdx = 0;
 
@@ -908,6 +914,177 @@ namespace Hooks_NetPacket_OnlineFix {
 
 
 // ════════════════════════════════════════════════════════════════
+//  Hooks_NetPacket_Cloud
+//
+//  Steam Cloud save redirection via CloudRedirect (cloud_redirect.dll).
+//
+//  Outgoing: ServiceMethodCallFromClient (eMsg 151) with target_job_name
+//            "Cloud.*" for an addappid()-unlocked game.
+//  Incoming: a synthesized ServiceMethodResponse (eMsg 147) carrying the
+//            answer produced by CloudRedirect, correlated by jobid.
+//
+//  CloudRedirect answers the RPC locally (reading/writing the real save
+//  bytes to the user's cloud provider). We therefore SUPPRESS the outbound
+//  request (it must not reach Valve) and DELIVER the response the same way
+//  the RichPresence path injects packets: by borrowing the next inbound
+//  "carrier" packet for one oRecvPkt call (CloudRedirect's "Approach D").
+// ════════════════════════════════════════════════════════════════
+namespace Hooks_NetPacket_Cloud {
+
+    std::mutex                     g_queueMutex;
+    std::deque<std::vector<uint8>> g_pending;        // ready-to-inject 147 packets
+    uint64                         g_localSteamId = 0;
+
+    // ── minimal top-level protobuf varint field reader ──────────
+    // Avoids pulling the Cloud.* request message definitions into the
+    // proto set just to read one appid field.
+    static bool ReadVarint(const uint8* d, uint32 size, uint32& pos, uint64& out) {
+        out = 0;
+        int shift = 0;
+        while (pos < size) {
+            uint8 b = d[pos++];
+            out |= static_cast<uint64>(b & 0x7F) << shift;
+            if (!(b & 0x80)) return true;
+            shift += 7;
+            if (shift >= 64) return false;
+        }
+        return false;
+    }
+
+    static bool FindVarintField(const uint8* d, uint32 size, uint32 target, uint64& out) {
+        uint32 pos = 0;
+        while (pos < size) {
+            uint64 tag;
+            if (!ReadVarint(d, size, pos, tag)) return false;
+            const uint32 field   = static_cast<uint32>(tag >> 3);
+            const uint32 wireType = static_cast<uint32>(tag & 7);
+            if (field == target && wireType == 0)
+                return ReadVarint(d, size, pos, out);
+
+            switch (wireType) {
+            case 0: { uint64 tmp; if (!ReadVarint(d, size, pos, tmp)) return false; break; }
+            case 1: if (pos + 8 > size) return false; pos += 8; break;
+            case 5: if (pos + 4 > size) return false; pos += 4; break;
+            case 2: {
+                uint64 len;
+                if (!ReadVarint(d, size, pos, len)) return false;
+                if (pos + len > size) return false;
+                pos += static_cast<uint32>(len);
+                break;
+            }
+            default: return false;   // groups (3/4) — bail
+            }
+        }
+        return false;
+    }
+
+    // appid lives in field 1 of every Cloud.* request except
+    // ClientCommitFileUpload, where it is field 2 (mirrors CloudRedirect's
+    // CloudRpcUtils::ExtractAppId).
+    static uint32 ExtractAppId(const char* jobName, const uint8* body, uint32 cbBody) {
+        uint32 fieldNum = 1;
+        if (std::strcmp(jobName, "Cloud.ClientCommitFileUpload#1") == 0)
+            fieldNum = 2;
+        uint64 v = 0;
+        if (FindVarintField(body, cbBody, fieldNum, v))
+            return static_cast<uint32>(v);
+        return 0;
+    }
+
+    // Returns true when CloudRedirect handled the request — the caller must
+    // then suppress the outbound frame.
+    bool HandleSend(const char* jobName,
+                    const uint8* pBody, uint32 cbBody,
+                    const uint8* pHdr, uint32 cbHdr)
+    {
+        if (!CloudRedirectHost::IsActive()) return false;
+
+        CMsgProtoBufHeader reqHdr;
+        if (!reqHdr.ParseFromArray(pHdr, cbHdr)) return false;
+        if (reqHdr.has_steamid() && reqHdr.steamid())
+            g_localSteamId = reqHdr.steamid();
+
+        const uint32 appId = ExtractAppId(jobName, pBody, cbBody);
+        if (appId == 0 || !CloudRedirectHost::IsApp(appId)) return false;
+
+        const uint32 accountId = static_cast<uint32>(g_localSteamId & 0xFFFFFFFFull);
+
+        static thread_local uint8 respBuf[kMaxBodySize];
+        uint32  respLen  = 0;
+        int32_t eresult  = 2;   // EResult::Fail
+        if (!CloudRedirectHost::HandleCloudRpc(jobName, appId, accountId,
+                                               pBody, cbBody,
+                                               respBuf, static_cast<uint32_t>(sizeof(respBuf)),
+                                               &respLen, &eresult)) {
+            return false;   // not a namespace app / unrecognised — let it pass through
+        }
+
+        // Build the 147 ServiceMethodResponse correlated to the request job.
+        CMsgProtoBufHeader respHdr;
+        if (reqHdr.has_jobid_source()) respHdr.set_jobid_target(reqHdr.jobid_source());
+        respHdr.set_eresult(eresult);
+        respHdr.set_target_job_name(jobName);
+
+        const uint32 cbRespHdr = static_cast<uint32>(respHdr.ByteSizeLong());
+        const uint32 total     = sizeof(MsgHdr) + cbRespHdr + respLen;
+        if (cbRespHdr > kMaxHdrSize || respLen > kMaxBodySize || total > kMaxPacketSize) {
+            // Can't deliver a response this big — fall through so Steam errors
+            // normally instead of leaving the job hung.
+            LOG_NETPACKET_WARN("Cloud: {} response too large ({} bytes), passing through",
+                               jobName, total);
+            return false;
+        }
+
+        std::vector<uint8> pkt(total);
+        auto* mhdr = reinterpret_cast<MsgHdr*>(pkt.data());
+        mhdr->eMsg = static_cast<EMsg>(
+            static_cast<uint32>(k_EMsgServiceMethodResponse) | kMsgHdrProtoFlag);
+        mhdr->headerLength = cbRespHdr;
+        if (!respHdr.SerializeToArray(pkt.data() + sizeof(MsgHdr), cbRespHdr))
+            return false;
+        if (respLen)
+            memcpy(pkt.data() + sizeof(MsgHdr) + cbRespHdr, respBuf, respLen);
+
+        {
+            std::lock_guard lk(g_queueMutex);
+            if (g_pending.size() < 64)
+                g_pending.push_back(std::move(pkt));
+        }
+        LOG_NETPACKET_DEBUG("Cloud: handled {} app={} -> queued {}-byte response (eresult={})",
+                            jobName, appId, total, eresult);
+        return true;
+    }
+
+    // Deliver any queued cloud responses by borrowing the carrier packet for
+    // one oRecvPkt call each (same trick as RichPresence::TryInject). Runs on
+    // the network thread from inside the RecvPkt hook.
+    void Drain(void* pThis, CNetPacket* pCarrier,
+               bool (*invokeOriginal)(void*, CNetPacket*))
+    {
+        for (;;) {
+            std::vector<uint8> pkt;
+            {
+                std::lock_guard lk(g_queueMutex);
+                if (g_pending.empty()) return;
+                pkt = std::move(g_pending.front());
+                g_pending.pop_front();
+            }
+
+            uint8* origData = pCarrier->m_pubData;
+            uint32 origSize = pCarrier->m_cubData;
+            pCarrier->m_pubData = pkt.data();
+            pCarrier->m_cubData = static_cast<uint32>(pkt.size());
+            invokeOriginal(pThis, pCarrier);
+            pCarrier->m_pubData = origData;
+            pCarrier->m_cubData = origSize;
+            LOG_NETPACKET_DEBUG("Cloud: delivered {}-byte response", pkt.size());
+        }
+    }
+
+} // namespace Hooks_NetPacket_Cloud
+
+
+// ════════════════════════════════════════════════════════════════
 //  Dispatch
 // ════════════════════════════════════════════════════════════════
 namespace {
@@ -917,6 +1094,16 @@ namespace {
                         const uint8* pHdr, uint32 cbHdr)
     {
         LOG_NETPACKET_DEBUG("Send target_job_name: {}", targetJobName);
+
+        // Steam Cloud save redirection: hand every "Cloud.*" request to
+        // CloudRedirect. If it answers, suppress the outbound frame (the
+        // synthesized response is delivered from the RecvPkt hook).
+        if (std::strncmp(targetJobName, "Cloud.", 6) == 0) {
+            if (Hooks_NetPacket_Cloud::HandleSend(targetJobName, pBody, cbBody, pHdr, cbHdr))
+                g_SuppressSend = true;
+            return false;   // never body-replace a cloud frame
+        }
+
         switch (Fnv1aHash(targetJobName)) {
 
         case HASH_JOB_GetUserStats:
@@ -934,6 +1121,7 @@ namespace {
                  const uint8* pHdr, uint32 cbHdr)
     {
         g_NeedReplaceSend = false;
+        g_SuppressSend    = false;
 
         LOG_NETPACKET_DEBUG("Send eMsg {}({}) (cbBody={}, cbHdr={})",
                         MsgName(eMsg), static_cast<uint32>(eMsg), cbBody, cbHdr);
@@ -1059,6 +1247,12 @@ namespace {
         if (UnpackRaw(pubData, cubData, eMsg, pHdr, cbHdr, pBody, cbBody)) {
             SendJob(eMsg, pBody, cbBody, pHdr, cbHdr);
 
+            if (g_SuppressSend) {
+                // CloudRedirect answered this RPC locally; do not forward to
+                // Valve. Report success so Steam treats the frame as sent.
+                return true;
+            }
+
             if (g_NeedReplaceSend) {
                 uint32 newSize = 0;
                 uint8* buf = ReplaceSendPacket(pubData, cbHdr, pHdr,
@@ -1079,6 +1273,10 @@ namespace {
     HOOK_FUNC(RecvPkt, void*, void* pThis, CNetPacket* pPacket)
     {
         Hooks_NetPacket_RichPresence::TryInject(
+            pThis, pPacket,
+            [](void* pT, CNetPacket* pP) -> bool { return oRecvPkt(pT, pP) != nullptr; });
+
+        Hooks_NetPacket_Cloud::Drain(
             pThis, pPacket,
             [](void* pT, CNetPacket* pP) -> bool { return oRecvPkt(pT, pP) != nullptr; });
 

--- a/src/Hook/Hooks_Package.cpp
+++ b/src/Hook/Hooks_Package.cpp
@@ -97,7 +97,6 @@ namespace {
         bool result = oCheckAppOwnership(pObj, appId, pOwn);
         TryInitFakeLicenseOnce();
 
-        // LOG_PACKAGE_TRACE("CheckAppOwnership: AppId={} result={} {}", appId, result, pOwn->DebugString());
         if (LuaConfig::HasDepot(appId,false)) {
             if (result && pOwn->ExistInPackageNums > 1) {
                 // Actually owned — record so HasDepot excludes it going forward
@@ -106,6 +105,7 @@ namespace {
             } else {
                 pOwn->PackageId    = kInjectedPackageId;
                 pOwn->ReleaseState = EAppReleaseState::Released;
+                pOwn->bOwnsLicense = true; //This forces DLCs on steam family shared games that u dont own when adding their appid via .lua
                 // Setting this free flag to false will hide it from the library UI.
                 pOwn->bFreeLicense = false;
                 return true;

--- a/src/Utils/CloudRedirect/CloudRedirectHost.cpp
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.cpp
@@ -1,0 +1,168 @@
+#include "CloudRedirectHost.h"
+
+#include "OSTPlatform/include/DynamicLibrary.h"
+#include "Utils/Config/Config.h"
+#include "Utils/Config/LuaConfig.h"
+#include "Utils/Logging/Log.h"
+
+#include <atomic>
+#include <filesystem>
+#include <mutex>
+#include <vector>
+
+namespace CloudRedirectHost {
+namespace {
+
+    // --- CloudRedirect third-party client ABI (CloudRedirect/src/common/cr_api.h)
+    // Declared locally so OpenSteamTool does not need CloudRedirect's headers.
+    using CR_NotifyFn        = void (*)(int level, const char* title, const char* message);
+    using CR_InitCloudSave_t = bool (*)(const char* steamPath, CR_NotifyFn notify);
+    using CR_HandleCloudRpc_t = bool (*)(const char* method, uint32_t appId, uint32_t accountId,
+                                         const uint8_t* reqBody, uint32_t reqLen,
+                                         uint8_t* respBuf, uint32_t respMaxLen,
+                                         uint32_t* respLen, int32_t* eresult);
+    using CR_AddApp_t   = void (*)(uint32_t appId);
+    using CR_RemoveApp_t = void (*)(uint32_t appId);
+    using CR_IsApp_t    = bool (*)(uint32_t appId);
+    using CR_SetApps_t  = void (*)(const uint32_t* appIds, uint32_t count);
+    using CR_Shutdown_t = void (*)();
+
+    std::mutex        g_mutex;
+    std::atomic<bool> g_active{false};
+    OSTPlatform::DynamicLibrary::ModuleHandle g_module = nullptr;
+
+    CR_InitCloudSave_t  g_initCloudSave  = nullptr;
+    CR_HandleCloudRpc_t g_handleCloudRpc = nullptr;
+    CR_SetApps_t        g_setApps        = nullptr;
+    CR_IsApp_t          g_isApp          = nullptr;
+    CR_Shutdown_t       g_shutdownFn     = nullptr;
+
+    // Routes CloudRedirect's notifications into OpenSteamTool's log instead of
+    // popping a MessageBox from inside Steam.
+    void CloudNotify(int level, const char* title, const char* message) {
+        const char* t = title ? title : "CloudRedirect";
+        const char* m = message ? message : "";
+        switch (level) {
+        case 2:  LOG_ERROR("[CloudRedirect] {}: {}", t, m); break;
+        case 1:  LOG_WARN("[CloudRedirect] {}: {}", t, m);  break;
+        default: LOG_INFO("[CloudRedirect] {}: {}", t, m);  break;
+        }
+    }
+
+    std::filesystem::path ResolveLibraryPath(const std::string& steamRoot,
+                                             const std::string& configured) {
+        if (configured.empty())
+            return std::filesystem::path(steamRoot) / "cloud_redirect.dll";
+
+        std::filesystem::path lib(configured);
+        if (lib.is_absolute())
+            return lib;
+        return std::filesystem::path(steamRoot) / lib;
+    }
+
+    template <typename T>
+    bool ResolveSymbol(OSTPlatform::DynamicLibrary::ModuleHandle module,
+                       const char* name, T& out) {
+        out = reinterpret_cast<T>(OSTPlatform::DynamicLibrary::GetSymbol(module, name));
+        if (!out) {
+            LOG_WARN("CloudRedirect: export {} not found in cloud_redirect.dll", name);
+            return false;
+        }
+        return true;
+    }
+
+} // namespace
+
+void Initialize(const char* steamInstallPath) {
+    const Config::CloudSettings cloud = Config::GetCloudSettings();
+    if (!cloud.enabled) {
+        LOG_INFO("CloudRedirect: [cloud].enabled is false, cloud save redirection disabled");
+        return;
+    }
+    if (!steamInstallPath || steamInstallPath[0] == '\0') {
+        LOG_WARN("CloudRedirect: empty Steam install path, cannot initialise");
+        return;
+    }
+
+    std::lock_guard lock(g_mutex);
+    if (g_active.load(std::memory_order_acquire)) return;
+
+    const std::filesystem::path libPath = ResolveLibraryPath(steamInstallPath, cloud.library);
+    if (!std::filesystem::exists(libPath)) {
+        LOG_WARN("CloudRedirect: cloud_redirect.dll not found at {}", libPath.string());
+        return;
+    }
+
+    g_module = OSTPlatform::DynamicLibrary::Load(libPath);
+    if (!g_module) {
+        LOG_WARN("CloudRedirect: failed to load {} (err={})",
+                 libPath.string(), OSTPlatform::DynamicLibrary::GetLastErrorCode());
+        return;
+    }
+
+    bool ok = true;
+    ok &= ResolveSymbol(g_module, "CR_InitCloudSave",  g_initCloudSave);
+    ok &= ResolveSymbol(g_module, "CR_HandleCloudRpc", g_handleCloudRpc);
+    ok &= ResolveSymbol(g_module, "CR_SetApps",        g_setApps);
+    ok &= ResolveSymbol(g_module, "CR_IsApp",          g_isApp);
+    ok &= ResolveSymbol(g_module, "CR_Shutdown",       g_shutdownFn);
+    if (!ok) {
+        LOG_WARN("CloudRedirect: cloud_redirect.dll is missing required exports, disabling");
+        g_module = nullptr;
+        return;
+    }
+
+    if (!g_initCloudSave(steamInstallPath, &CloudNotify)) {
+        LOG_WARN("CloudRedirect: CR_InitCloudSave failed, disabling cloud save redirection");
+        g_module = nullptr;
+        return;
+    }
+
+    g_active.store(true, std::memory_order_release);
+    LOG_INFO("CloudRedirect: loaded {} and initialised cloud save redirection",
+             libPath.string());
+
+    // Push the current unlocked-app set without re-locking g_mutex.
+    std::vector<AppId_t> depots = LuaConfig::GetAllDepotIds();
+    std::vector<uint32_t> appIds(depots.begin(), depots.end());
+    g_setApps(appIds.empty() ? nullptr : appIds.data(),
+              static_cast<uint32_t>(appIds.size()));
+    LOG_INFO("CloudRedirect: registered {} redirected app(s)", appIds.size());
+}
+
+void SyncAppSet() {
+    if (!g_active.load(std::memory_order_acquire) || !g_setApps) return;
+
+    std::vector<AppId_t> depots = LuaConfig::GetAllDepotIds();
+    std::vector<uint32_t> appIds(depots.begin(), depots.end());
+    g_setApps(appIds.empty() ? nullptr : appIds.data(),
+              static_cast<uint32_t>(appIds.size()));
+    LOG_DEBUG("CloudRedirect: re-synced redirected app set ({} app(s))", appIds.size());
+}
+
+bool IsActive() {
+    return g_active.load(std::memory_order_acquire);
+}
+
+bool IsApp(uint32_t appId) {
+    if (!g_active.load(std::memory_order_acquire) || !g_isApp) return false;
+    return g_isApp(appId);
+}
+
+bool HandleCloudRpc(const char* method, uint32_t appId, uint32_t accountId,
+                    const uint8_t* reqBody, uint32_t reqLen,
+                    uint8_t* respBuf, uint32_t respMaxLen,
+                    uint32_t* respLen, int32_t* eresult) {
+    if (!g_active.load(std::memory_order_acquire) || !g_handleCloudRpc) return false;
+    return g_handleCloudRpc(method, appId, accountId, reqBody, reqLen,
+                            respBuf, respMaxLen, respLen, eresult);
+}
+
+void Shutdown() {
+    std::lock_guard lock(g_mutex);
+    if (!g_active.exchange(false)) return;
+    if (g_shutdownFn) g_shutdownFn();
+    LOG_INFO("CloudRedirect: shut down");
+}
+
+} // namespace CloudRedirectHost

--- a/src/Utils/CloudRedirect/CloudRedirectHost.h
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cstdint>
+
+// Hosts CloudRedirect's prebuilt cloud_redirect.dll inside the Steam process and
+// drives its third-party client API (see CloudRedirect/src/common/cr_api.h):
+//   - loads the DLL and resolves the CR_* exports,
+//   - calls CR_InitCloudSave in cloud-save-only mode,
+//   - registers every addappid() game as a redirected ("namespace") app,
+//   - forwards Cloud.* RPCs from the NetPacket hook to CR_HandleCloudRpc.
+//
+// All entry points are safe no-ops unless [cloud].enabled is set and the DLL
+// loaded and initialised successfully.
+namespace CloudRedirectHost {
+
+    // Load + initialise. Called once from the init worker thread, after the
+    // Steam hooks are installed. steamInstallPath is the Steam root directory.
+    void Initialize(const char* steamInstallPath);
+
+    // Re-push the current unlocked-app set to CloudRedirect. Called after a Lua
+    // hot-reload so the redirected set tracks addappid() changes.
+    void SyncAppSet();
+
+    // True once the DLL is loaded and CR_InitCloudSave succeeded.
+    bool IsActive();
+
+    // Whether CloudRedirect is currently redirecting saves for this appid.
+    bool IsApp(uint32_t appId);
+
+    // Bridge from the NetPacket hook: forwards a single Cloud.* RPC to
+    // CloudRedirect. Returns false when not handled (caller chains to original).
+    bool HandleCloudRpc(const char* method, uint32_t appId, uint32_t accountId,
+                        const uint8_t* reqBody, uint32_t reqLen,
+                        uint8_t* respBuf, uint32_t respMaxLen,
+                        uint32_t* respLen, int32_t* eresult);
+
+    // Teardown. Called from DLL_PROCESS_DETACH.
+    void Shutdown();
+
+}

--- a/src/Utils/Config/Config.cpp
+++ b/src/Utils/Config/Config.cpp
@@ -19,6 +19,7 @@ namespace {
         std::string remoteUrlTemplate;
         bool statsEnableApi = true;
         InjectionSettings injection;
+        CloudSettings cloud;
     };
 
     std::mutex g_mutex;
@@ -55,6 +56,8 @@ namespace {
         injectEnabled          = snapshot.injection.enabled;
         injectLibraryX86       = snapshot.injection.libraryX86;
         injectLibraryX64       = snapshot.injection.libraryX64;
+        cloudEnabled           = snapshot.cloud.enabled;
+        cloudLibrary           = snapshot.cloud.library;
     }
 
     void ApplyManifestProvider(const std::string& provider) {
@@ -155,6 +158,14 @@ namespace {
                     snapshot.injection.libraryX64 = *val;
             }
 
+            // [cloud]
+            if (auto cloud = tbl["cloud"].as_table()) {
+                if (auto val = (*cloud)["enabled"].value<bool>())
+                    snapshot.cloud.enabled = *val;
+                if (auto val = (*cloud)["library"].value<std::string>())
+                    snapshot.cloud.library = *val;
+            }
+
             ApplyManifestProvider(snapshot.manifestProvider);
             LoadResult result = ApplySnapshotLocked(snapshot);
             LOG_INFO("Config loaded: manifest.url={} log.level={} lua.paths={} stats.enable_api={} remote.url_template={}",
@@ -228,6 +239,14 @@ namespace {
     bool GetStatsEnableApi() {
         std::lock_guard lock(g_mutex);
         return statsEnableApi;
+    }
+
+    CloudSettings GetCloudSettings() {
+        std::lock_guard lock(g_mutex);
+        return {
+            cloudEnabled,
+            cloudLibrary,
+        };
     }
 
 }

--- a/src/Utils/Config/Config.h
+++ b/src/Utils/Config/Config.h
@@ -21,6 +21,11 @@ namespace Config {
         std::string libraryX64;
     };
 
+    struct CloudSettings {
+        bool enabled = false;
+        std::string library;
+    };
+
     struct LoadResult {
         bool applied = false;
         bool luaPathsChanged = false;
@@ -34,6 +39,7 @@ namespace Config {
     std::vector<std::string> GetLuaPaths();
     std::string GetRemoteUrlTemplate();
     InjectionSettings GetInjectionSettings();
+    CloudSettings GetCloudSettings();
     bool GetStatsEnableApi();
 
     // [manifest] — provider selection lives in ManifestClient (table-driven).
@@ -61,5 +67,9 @@ namespace Config {
     inline bool injectEnabled = false;
     inline std::string injectLibraryX86;
     inline std::string injectLibraryX64;
+
+    // [cloud] - optional Steam Cloud save redirection via CloudRedirect.
+    inline bool cloudEnabled = false;
+    inline std::string cloudLibrary;
 
 }

--- a/src/Utils/Config/LuaFileWatcher.cpp
+++ b/src/Utils/Config/LuaFileWatcher.cpp
@@ -1,6 +1,7 @@
 #include "Hook/Hooks_Package.h"
 #include "Utils/Config/LuaFileWatcher.h"
 #include "Utils/Config/LuaConfig.h"
+#include "Utils/CloudRedirect/CloudRedirectHost.h"
 #include "Utils/Logging/Log.h"
 #include "OSTPlatform/include/DirectoryWatch.h"
 
@@ -115,6 +116,7 @@ void ProcessChanges(const std::vector<FileChange>& changes) {
     }
 
     Hooks_Package::NotifyLicenseChanged();
+    CloudRedirectHost::SyncAppSet();
     LOG_PACKAGE_DEBUG("Lua refresh completed");
 }
 

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -2,6 +2,7 @@
 #include "Hook/HookManager.h"
 #include "Utils/Config/ConfigFileWatcher.h"
 #include "Utils/Config/LuaFileWatcher.h"
+#include "Utils/CloudRedirect/CloudRedirectHost.h"
 #include "Utils/SteamMetadata/IPCLoader.h"
 #include "Utils/SteamMetadata/PatternLoader.h"
 #include "Utils/SteamMetadata/SteamDiagnostics.h"
@@ -81,6 +82,10 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     // Surface any functions that FindPattern() could not locate.
     PatternLoader::ReportMissingFunctions();
 
+    // Optional Steam Cloud save redirection (CloudRedirect). No-op unless
+    // [cloud].enabled is set and cloud_redirect.dll is present.
+    CloudRedirectHost::Initialize(SteamInstallPath);
+
     LOG_INFO("OpenSteamTool init complete");
     return 0;
 }
@@ -102,6 +107,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, PVOID pvReserved)
         LuaFileWatcher::Stop();
         SteamUI::CoreUnhook();
         SteamClient::CoreUnhook();
+        CloudRedirectHost::Shutdown();
     }
 
     return TRUE;


### PR DESCRIPTION
This pull request introduces support for Steam Cloud save redirection for unlocked games using CloudRedirect, along with the necessary configuration and integration in the codebase. It adds a new `[cloud]` section in the config, implements the `CloudRedirectHost` module for hosting and interfacing with `cloud_redirect.dll`, and hooks into the network packet handling to intercept and redirect Steam Cloud RPCs for eligible games. The changes are organized into three main themes: feature addition, configuration, and integration with the network hooks.

**Feature: Steam Cloud Save Redirection**
- Added a new `CloudRedirectHost` module that loads and manages the `cloud_redirect.dll`, handles initialization, app registration, RPC forwarding, and shutdown, allowing OpenSteamTool to redirect Steam Cloud saves for unlocked games. (`src/Utils/CloudRedirect/CloudRedirectHost.cpp`, `src/Utils/CloudRedirect/CloudRedirectHost.h`) [[1]](diffhunk://#diff-da793cdbf9349cca443efdb1d544fb13dee846d1dcd7ab1fb26eab57502a8caaR1-R168) [[2]](diffhunk://#diff-7bac2a59813e2ae1e53c52f3c44098d66e17696ddcc13b04885188949da677a9R1-R40)
- Integrated the new module into the build system by updating `CMakeLists.txt`.

**Configuration: Cloud Section**
- Introduced a `[cloud]` section in the configuration file, allowing users to enable or disable cloud save redirection and specify the path to `cloud_redirect.dll`. (`opensteamtool.example.toml`, `src/Utils/Config/Config.cpp`) [[1]](diffhunk://#diff-db9835fbb912a96eeb87f486be0cdf8de10032b29b0abe52d6fc3b5b2e10f171R81-R94) [[2]](diffhunk://#diff-d9c6d2a9aee7ba3db775e3ede9ebd89240709b25a3b618bf707c8f778abbe27eR22) [[3]](diffhunk://#diff-d9c6d2a9aee7ba3db775e3ede9ebd89240709b25a3b618bf707c8f778abbe27eR59-R60) [[4]](diffhunk://#diff-d9c6d2a9aee7ba3db775e3ede9ebd89240709b25a3b618bf707c8f778abbe27eR161-R168) [[5]](diffhunk://#diff-d9c6d2a9aee7ba3db775e3ede9ebd89240709b25a3b618bf707c8f778abbe27eR244-R251)

**Integration: Network Packet Hooking**
- Updated the network packet hooks to intercept outgoing Steam Cloud RPCs (those with `target_job_name` starting with `"Cloud."`) and, if CloudRedirect is active and handles the request, suppress the outbound frame and deliver a synthesized response locally. (`src/Hook/Hooks_NetPacket.cpp`) [[1]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R8-R15) [[2]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R45) [[3]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R916-R1086) [[4]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R1097-R1106) [[5]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R1124) [[6]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R1250-R1255) [[7]](diffhunk://#diff-8e2d8c11c1c82bb1e1b678f14154e18ec897986fe79176501c7edcbced0e2ba3R1279-R1282)

These changes enable OpenSteamTool to optionally redirect Steam Cloud saves for unlocked games to CloudRedirect.