### PR TITLE
fix(DenuvoAuth): engage auth path when signature scan misses but an eticket is injected

### DIFF
--- a/src/Pipe/Features/DenuvoAuth/DenuvoAuth.cpp
+++ b/src/Pipe/Features/DenuvoAuth/DenuvoAuth.cpp
@@ -151,7 +151,7 @@ namespace {
         return authIt == g_processAuth.end() ? nullptr : &authIt->second;
     }
 
-    void EnsureScanned(ProcessAuth& auth, const ProcessKey& process) {
+    void EnsureScanned(ProcessAuth& auth, const ProcessKey& process, AppId_t appId) {
         if (auth.scanned) {
             LOG_PIPE_TRACE("DenuvoAuth: reusing cached protection result {} denuvo={}",
                            process.DebugString(), auth.denuvo);
@@ -160,6 +160,15 @@ namespace {
 
         auth.scanned = true;
         auth.denuvo = ScanProtection(process.pid).denuvoDetected;
+        // Fallback when signature detection misses a real Denuvo title (some builds
+        // slip both the OEP and legacy-string heuristics). An injected
+        // EncryptedAppTicket for this app means the user intends Denuvo auth, so
+        // engage the auth path instead of giving up.
+        if (!auth.denuvo &&
+            !AppTicket::GetEncryptedTicketFromCredentialStore(appId).empty()) {
+            LOG_PIPE_INFO("DenuvoAuth: scan missed but injected eticket present; treating as Denuvo appid={}", appId);
+            auth.denuvo = true;
+        }
         if (!auth.denuvo) auth.stage = Stage::None;
     }
 
@@ -174,7 +183,7 @@ void Apply(const PipeContext& ctx) {
     ProcessAuth& auth = g_processAuth[ctx.process];
     g_pipeProcess[pipeKey] = ctx.process;
 
-    EnsureScanned(auth, ctx.process);
+    EnsureScanned(auth, ctx.process, ctx.appId);
     auth.OnHandshake(ctx, pipeKey);
 }
 


### PR DESCRIPTION
## Problem

`ProtectionScan` only recognizes Denuvo via two signatures scanned on the **on-disk** PE: the OEP `mov rcx, "DODENUVO"` immediate, and the literal `DENUVO` string in a legacy section. Some titles ship a Denuvo build that slips **both** heuristics (the markers are absent / encrypted on disk).

When that happens, `denuvoDetected` stays `false`, the authorization window never opens, and `GetAppOwnershipTicket` falls back to the forged appid-7 ownership ticket instead of the genuine one from the credential store — which Denuvo's license server rejects (e.g. `885000051`).

## Change

In `EnsureScanned`, when signature detection misses, fall back to checking whether an `EncryptedAppTicket` has been injected for the app. `setAppTicket`/`setETicket` are only used for ticket-gated (Denuvo) titles, so an injected eticket is a strong "the user intends Denuvo auth" signal; treat the app as Denuvo and engage the auth path instead of giving up.

No behavior change for already-detected titles, or for apps without an injected eticket.

## Verified

Sonic Forces (appid `637100`): the scan misses both signatures (confirmed in `pipe.log` — `no Denuvo match`), so auth never engaged and Denuvo failed with `885000051`. With this change the fallback fires (`scan missed but injected eticket present; treating as Denuvo`), the authorization window opens (`handshakeCount=1`), the real ownership ticket is served from the credential store, and the title launches.

## Notes

Complements the size-floor miss in #121: that covers titles whose `.exe` falls under the 80 MB floor; this covers titles that **pass** the floor and are scanned but still slip both signature heuristics. The auth-window timing (`kEndDenuvoVerificationHandshake`) is left unchanged — for `637100` the ownership-ticket IPC lands within the existing window (`handshakeCount` stays at 1).
