### PR TITLE
fix: broadcast rich presence for unowned games to friends

### DIFF
--- a/src/Hook/Hooks_NetPacket.cpp
+++ b/src/Hook/Hooks_NetPacket.cpp
@@ -6,8 +6,10 @@
 #include "Utils/Tickets/AppTicket.h"
 #include "Utils/Support/FnvHash.h"
 #include <chrono>
+#include <filesystem>
 #include <future>
 #include <unordered_map>
+#include <vector>
 
 #include "steam_messages.pb.h"
 
@@ -855,6 +857,38 @@ namespace Hooks_NetPacket_RichPresence {
 // ════════════════════════════════════════════════════════════════
 namespace Hooks_NetPacket_OnlineFix {
 
+    // Scan all userdata shortcuts.vdf for the first shortcut appid.
+    // Returns its CGameID (type=shortcut, modid=appid) or 0 if none found.
+    static uint64 FindShortcutGameId()
+    {
+        static uint64 s_cached = 0;
+        static bool   s_tried  = false;
+        if (s_tried) return s_cached;
+        s_tried = true;
+
+        std::error_code ec;
+        for (const auto& entry : std::filesystem::directory_iterator(
+                 std::string(SteamInstallPath) + "\\userdata", ec)) {
+            if (!entry.is_directory()) continue;
+            std::ifstream f(entry.path().string() + "\\config\\shortcuts.vdf",
+                            std::ios::binary);
+            if (!f) continue;
+            std::vector<uint8> data((std::istreambuf_iterator<char>(f)),
+                                     std::istreambuf_iterator<char>());
+            const uint8 kMarker[] = {0x02, 'a','p','p','i','d', 0x00};
+            for (size_t i = 0; i + sizeof(kMarker) + 4 <= data.size(); ++i) {
+                if (memcmp(&data[i], kMarker, sizeof(kMarker)) == 0) {
+                    uint32 appId;
+                    memcpy(&appId, &data[i + sizeof(kMarker)], 4);
+                    s_cached = (static_cast<uint64>(appId) << 32) | (2ULL << 24);
+                    LOG_ONLINEFIX_INFO("Shortcut game_id=0x{:016X}", s_cached);
+                    return s_cached;
+                }
+            }
+        }
+        return 0;
+    }
+
     bool HandleSend(const uint8* pBody, uint32 cbBody,
                     const uint8* pHdr, uint32 cbHdr)
     {
@@ -872,8 +906,6 @@ namespace Hooks_NetPacket_OnlineFix {
             auto* game = msg.mutable_games_played(i);
             AppId_t appid = static_cast<AppId_t>(game->game_id() & UINT32_MAX);
 
-            // SpawnProcess rewrites pGameID to 480, so game_id is already 480.
-            // Fill game_extra_info with the real game name.
             if (appid == kOnlineFixAppId) {
                 AppId_t realAppId = Hooks_Misc::ResolveAppId();
                 if (realAppId && LuaConfig::HasDepot(realAppId)) {
@@ -881,13 +913,33 @@ namespace Hooks_NetPacket_OnlineFix {
                     if (!name.empty()) {
                         game->set_game_extra_info(name);
                         patched = true;
-                        LOG_ONLINEFIX_INFO("OnlineFix: 480 -> name '{}' (real appid {})",
-                            name, realAppId);
+                        LOG_ONLINEFIX_INFO("OnlineFix: 480 -> name '{}'", name);
                     }
                 }
             }
         }
 
+        // Rich Presence: rewrite topmost unowned game to use the first
+        // available shortcut's game_id so the server broadcasts it as a
+        // non-Steam game. Falls back to 480 if no shortcuts registered.
+        if (!patched) {
+            AppId_t trackedId = Hooks_NetPacket_RichPresence::g_PlayingAppId;
+            if (trackedId != 0 && trackedId != kOnlineFixAppId) {
+                std::string name = Hooks_Misc::GetGameNameByAppID(trackedId);
+                if (!name.empty()) {
+                    auto* topGame = msg.mutable_games_played(msg.games_played_size() - 1);
+                    uint64 shortcutId = FindShortcutGameId();
+                    if (shortcutId) {
+                        topGame->set_game_id(shortcutId);
+                    } else {
+                        topGame->set_game_id(kOnlineFixAppId);
+                    }
+                    topGame->set_game_extra_info(name);
+                    patched = true;
+                    LOG_ONLINEFIX_INFO("RichPresence: appid {} -> name '{}'", trackedId, name);
+                }
+            }
+        }
         if (!patched) return false;
 
         g_cbSendNewBody = static_cast<uint32>(msg.ByteSizeLong());


### PR DESCRIPTION
﻿Steam's server drops CMsgClientPersonaState buddy broadcasts for appids
the account doesn't own.  This means friends never see the user playing
an unlocked (addappid'd) game — they only see "Online".

The existing OnlineFix::HandleSend already rewrites -onlinefix games
(appid 480) to include game_extra_info for the correct title.  This
patch adds a fallback: when no onlinefix entry exists but the Rich
Presence module is tracking an unowned game via g_PlayingAppId, the
topmost game entry in the outbound CMsgClientGamesPlayed is rewritten
to appid 480 (SpaceWar, owned by every account) with game_extra_info
set to the real localized name.

The server sees 480 (owned), broadcasts the persona state, and friends
see the correct game title from game_extra_info.  The rewrite is
isolated to the outbound network packet only, no local state affected.
