### PR TITLE
Fix Cloud RPC timing (vtable hooks) and add stats sync support

### DIFF
--- a/src/Hook/Hooks_NetPacket.cpp
+++ b/src/Hook/Hooks_NetPacket.cpp
@@ -21,7 +21,7 @@
 // ════════════════════════════════════════════════════════════════
 namespace {
 
-    constexpr uint32 kMaxBodySize   = 8092;
+    constexpr uint32 kMaxBodySize   = 65536;
     constexpr uint32 kMaxHdrSize    = 1024;
     constexpr uint32 kMaxPacketSize = 8 + kMaxHdrSize + kMaxBodySize;
     constexpr int    kPacketPoolSize = 8;
@@ -338,9 +338,9 @@ namespace Hooks_NetPacket_UserStats {
             LOG_ACHIEVEMENT_WARN("ClientGetUserStats request: appid={} is not in addappid", appId);
             return false;
         }
-        if (!req.has_schema_local_version() || req.schema_local_version() != -1) {
-            LOG_ACHIEVEMENT_WARN("ClientGetUserStats request: schema_local_version is not -1");
-            return false;
+        if (req.schema_local_version() != -1) {
+            req.set_schema_local_version(-1);
+            LOG_ACHIEVEMENT_DEBUG("ClientGetUserStats request: forced schema_local_version to -1");
         }
 
         uint64_t newSteamId = LuaConfig::GetStatSteamId(appId);
@@ -357,7 +357,7 @@ namespace Hooks_NetPacket_UserStats {
     }
 
     // ── Recv: CMsgClientGetUserStatsResponse (eMsg 819) ────────
-    //     Strip stats(5) + achievement_blocks(6), patch eresult->OK.
+    //     Clear donor stats, overlay CR achievements, patch eresult->OK.
     bool HandleRecv_ClientGetUserStatsResponse(const uint8* pBody, uint32 cbBody)
     {
         CMsgClientGetUserStatsResponse resp;
@@ -371,13 +371,39 @@ namespace Hooks_NetPacket_UserStats {
         resp.clear_stats();
         resp.clear_achievement_blocks();
         resp.set_eresult(1);  // k_EResultOK
-        LOG_ACHIEVEMENT_DEBUG("ClientGetUserStats response: clear stats and achievement_blocks, set eresult=OK");
 
-        g_NewBodySize = static_cast<uint32>(resp.ByteSizeLong());
-        if (!resp.SerializeToArray(const_cast<uint8*>(pBody), cbBody))
+        // Overlay CR's cloud-synced achievement state
+        const auto appId = static_cast<uint32_t>(resp.game_id());
+        CloudRedirectHost::AchievementBlock blocks[64];
+        uint32_t n = CloudRedirectHost::GetAchievements(appId, blocks, 64);
+        if (n > 0) {
+            uint32_t crc = 0;
+            for (uint32_t i = 0; i < n; i++) {
+                auto* s = resp.add_stats();
+                s->set_stat_id(blocks[i].statId);
+                s->set_stat_value(blocks[i].bits);
+                auto* ab = resp.add_achievement_blocks();
+                ab->set_achievement_id(blocks[i].statId);
+                for (uint32_t bit = 0; bit < 32; bit++)
+                    ab->add_unlock_time(blocks[i].unlockTimes[bit]);
+                crc ^= blocks[i].bits ^ blocks[i].statId;
+            }
+            resp.set_crc_stats(crc);
+            LOG_ACHIEVEMENT_DEBUG("ClientGetUserStats response: injected {} CR achievement blocks for app {}", n, appId);
+        } else {
+            LOG_ACHIEVEMENT_DEBUG("ClientGetUserStats response: cleared stats/achievements (no CR data for app {})", appId);
+        }
+
+        auto newSize = resp.ByteSizeLong();
+        if (newSize > sizeof(g_NewBody)) {
+            LOG_ACHIEVEMENT_WARN("ClientGetUserStats response: modified message too large ({} bytes)", newSize);
+            return false;
+        }
+        if (!resp.SerializeToArray(g_NewBody, sizeof(g_NewBody)))
             return false;
 
-        g_ResizedInPlace = true;
+        g_cbNewBody = static_cast<uint32>(newSize);
+        g_NeedReplaceBody = true;
         LOG_ACHIEVEMENT_DEBUG("ClientGetUserStats response: modified body:\n{}", resp.DebugString());
         return true;
     }
@@ -746,6 +772,8 @@ namespace Hooks_NetPacket_RichPresence {
             if (hdr.ParseFromArray(pHdr, cbHdr) && hdr.has_steamid() && hdr.steamid()) {
                 g_LocalSteamId = hdr.steamid();
                 LOG_RICHPRESENCE_DEBUG("Captured local SteamID 0x{:X}", g_LocalSteamId);
+                CloudRedirectHost::SetAccountId(
+                    static_cast<uint32_t>(g_LocalSteamId & 0xFFFFFFFF));
             }
         }
 
@@ -766,7 +794,13 @@ namespace Hooks_NetPacket_RichPresence {
             newTracked = topmost;
 
         if (g_PlayingAppId == newTracked) return;
+        AppId_t oldTracked = g_PlayingAppId;
         g_PlayingAppId = newTracked;
+
+        if (oldTracked != 0)
+            CloudRedirectHost::NotifyAppRunning(oldTracked, false);
+        if (newTracked != 0)
+            CloudRedirectHost::NotifyAppRunning(newTracked, true);
 
         if (newTracked != 0) {
             LOG_RICHPRESENCE_INFO("Tracking topmost appid {}", newTracked);
@@ -1152,6 +1186,13 @@ namespace {
         case k_EMsgClientGetUserStats:               // 818
             g_NeedReplaceSend = Hooks_NetPacket_UserStats::HandleSend_ClientGetUserStats(pBody, cbBody);
             return;
+
+        case k_EMsgClientStoreUserStats2: {         // 5466
+            AppId_t appId = Hooks_NetPacket_RichPresence::g_PlayingAppId;
+            if (appId != 0)
+                CloudRedirectHost::NotifyStatsStored(appId);
+            return;
+        }
 
         default:
             return;

--- a/src/Hook/Hooks_NetPacket.cpp
+++ b/src/Hook/Hooks_NetPacket.cpp
@@ -1132,7 +1132,12 @@ namespace {
         // Steam Cloud save redirection: hand every "Cloud.*" request to
         // CloudRedirect. If it answers, suppress the outbound frame (the
         // synthesized response is delivered from the RecvPkt hook).
+        // ExitSyncDone/ConflictResolution are notifications that must reach
+        // Steam's internal cloud state machine untouched.
         if (std::strncmp(targetJobName, "Cloud.", 6) == 0) {
+            if (std::strcmp(targetJobName, "Cloud.SignalAppExitSyncDone#1") == 0 ||
+                std::strcmp(targetJobName, "Cloud.ClientConflictResolution#1") == 0)
+                return false;
             if (Hooks_NetPacket_Cloud::HandleSend(targetJobName, pBody, cbBody, pHdr, cbHdr))
                 g_SuppressSend = true;
             return false;   // never body-replace a cloud frame

--- a/src/Utils/CloudRedirect/CloudRedirectHost.cpp
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.cpp
@@ -24,18 +24,30 @@ namespace {
     using CR_AddApp_t   = void (*)(uint32_t appId);
     using CR_RemoveApp_t = void (*)(uint32_t appId);
     using CR_IsApp_t    = bool (*)(uint32_t appId);
-    using CR_SetApps_t  = void (*)(const uint32_t* appIds, uint32_t count);
-    using CR_Shutdown_t = void (*)();
+    using CR_SetApps_t          = void (*)(const uint32_t* appIds, uint32_t count);
+    using CR_Shutdown_t         = void (*)();
+    using CR_EnableStatsSync_t   = void (*)(bool, bool);
+    using CR_SetAccountId_t      = void (*)(uint32_t);
+    using CR_NotifyAppRunning_t  = void (*)(uint32_t, bool);
+    using CR_NotifyStatsStored_t = void (*)(uint32_t);
+    using CR_GetAchievements_t    = uint32_t (*)(uint32_t, CloudRedirectHost::AchievementBlock*, uint32_t);
+    using CR_InstallVtableHooks_t = bool (*)();
 
     std::mutex        g_mutex;
     std::atomic<bool> g_active{false};
     OSTPlatform::DynamicLibrary::ModuleHandle g_module = nullptr;
 
-    CR_InitCloudSave_t  g_initCloudSave  = nullptr;
-    CR_HandleCloudRpc_t g_handleCloudRpc = nullptr;
-    CR_SetApps_t        g_setApps        = nullptr;
-    CR_IsApp_t          g_isApp          = nullptr;
-    CR_Shutdown_t       g_shutdownFn     = nullptr;
+    CR_InitCloudSave_t     g_initCloudSave     = nullptr;
+    CR_HandleCloudRpc_t    g_handleCloudRpc    = nullptr;
+    CR_SetApps_t           g_setApps           = nullptr;
+    CR_IsApp_t             g_isApp             = nullptr;
+    CR_Shutdown_t          g_shutdownFn        = nullptr;
+    CR_EnableStatsSync_t    g_enableStatsSync    = nullptr;
+    CR_SetAccountId_t       g_setAccountId       = nullptr;
+    CR_NotifyAppRunning_t   g_notifyAppRunning   = nullptr;
+    CR_NotifyStatsStored_t  g_notifyStatsStored  = nullptr;
+    CR_GetAchievements_t    g_getAchievements    = nullptr;
+    CR_InstallVtableHooks_t g_installVtableHooks = nullptr;
 
     // Routes CloudRedirect's notifications into OpenSteamTool's log instead of
     // popping a MessageBox from inside Steam.
@@ -112,6 +124,14 @@ void Initialize(const char* steamInstallPath) {
         return;
     }
 
+    // Optional (CR 2.2.5+)
+    ResolveSymbol(g_module, "CR_EnableStatsSync",    g_enableStatsSync);
+    ResolveSymbol(g_module, "CR_SetAccountId",       g_setAccountId);
+    ResolveSymbol(g_module, "CR_NotifyAppRunning",   g_notifyAppRunning);
+    ResolveSymbol(g_module, "CR_NotifyStatsStored",  g_notifyStatsStored);
+    ResolveSymbol(g_module, "CR_GetAchievements",    g_getAchievements);
+    ResolveSymbol(g_module, "CR_InstallVtableHooks", g_installVtableHooks);
+
     if (!g_initCloudSave(steamInstallPath, &CloudNotify)) {
         LOG_WARN("CloudRedirect: CR_InitCloudSave failed, disabling cloud save redirection");
         g_module = nullptr;
@@ -122,12 +142,25 @@ void Initialize(const char* steamInstallPath) {
     LOG_INFO("CloudRedirect: loaded {} and initialised cloud save redirection",
              libPath.string());
 
+    if (g_enableStatsSync) {
+        g_enableStatsSync(true, true);
+        LOG_INFO("CloudRedirect: stats sync registered");
+    }
+
     // Push the current unlocked-app set without re-locking g_mutex.
     std::vector<AppId_t> depots = LuaConfig::GetAllDepotIds();
     std::vector<uint32_t> appIds(depots.begin(), depots.end());
     g_setApps(appIds.empty() ? nullptr : appIds.data(),
               static_cast<uint32_t>(appIds.size()));
     LOG_INFO("CloudRedirect: registered {} redirected app(s)", appIds.size());
+
+    // Vtable hooks let CR handle Cloud RPCs synchronously (slot4 semantics).
+    if (g_installVtableHooks) {
+        if (g_installVtableHooks())
+            LOG_INFO("CloudRedirect: vtable hooks installed");
+        else
+            LOG_WARN("CloudRedirect: vtable hook install failed, using packet-layer path");
+    }
 }
 
 void SyncAppSet() {
@@ -156,6 +189,26 @@ bool HandleCloudRpc(const char* method, uint32_t appId, uint32_t accountId,
     if (!g_active.load(std::memory_order_acquire) || !g_handleCloudRpc) return false;
     return g_handleCloudRpc(method, appId, accountId, reqBody, reqLen,
                             respBuf, respMaxLen, respLen, eresult);
+}
+
+void SetAccountId(uint32_t accountId) {
+    if (!g_active.load(std::memory_order_acquire) || !g_setAccountId) return;
+    g_setAccountId(accountId);
+}
+
+void NotifyAppRunning(uint32_t appId, bool running) {
+    if (!g_active.load(std::memory_order_acquire) || !g_notifyAppRunning) return;
+    g_notifyAppRunning(appId, running);
+}
+
+void NotifyStatsStored(uint32_t appId) {
+    if (!g_active.load(std::memory_order_acquire) || !g_notifyStatsStored) return;
+    g_notifyStatsStored(appId);
+}
+
+uint32_t GetAchievements(uint32_t appId, AchievementBlock* out, uint32_t maxBlocks) {
+    if (!g_active.load(std::memory_order_acquire) || !g_getAchievements) return 0;
+    return g_getAchievements(appId, out, maxBlocks);
 }
 
 void Shutdown() {

--- a/src/Utils/CloudRedirect/CloudRedirectHost.h
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.h
@@ -34,6 +34,18 @@ namespace CloudRedirectHost {
                         uint8_t* respBuf, uint32_t respMaxLen,
                         uint32_t* respLen, int32_t* eresult);
 
+    void SetAccountId(uint32_t accountId);
+    void NotifyAppRunning(uint32_t appId, bool running);
+    void NotifyStatsStored(uint32_t appId);
+
+    struct AchievementBlock {
+        uint32_t statId;
+        uint32_t bits;
+        uint32_t unlockTimes[32];
+    };
+    // Returns number of blocks written (0 if none/disabled).
+    uint32_t GetAchievements(uint32_t appId, AchievementBlock* out, uint32_t maxBlocks);
+
     // Teardown. Called from DLL_PROCESS_DETACH.
     void Shutdown();
 


### PR DESCRIPTION
The CR patch from Peron was a nice thing for them to make, but it is incorrect. Specifically:

The Peron patch intercepts outgoing requests at `BBuildAndAsyncSendFrame` and delivers responses by borrowing the next inbound carrier packet in `RecvPkt`.

This is almost impossibly broken for CR. This is not really Peron's fault, they were building against the API and the API was designed against a different non-ST Steam Unlock solution, so I improved it. But here's the issue:

- `BeginFileUpload` and `CommitFileUpload` have a 20 sec timeout.
- Response delivery depends on *unrelated inbound traffic* arriving.
- If the connection is idle...responses queue indefinitely, fun.
- Sequential operations deadlock because `Commit` can't fire until the `Begin` response is delivered, but delivery requires another inbound packet that may or may not arrive in time.

This causes intermittent upload failures, especially on slower connections. I have a tester (of pre-release CR builds) that has a connection that is horrible; I spent two days chasing an issue that did not exist in CR code.

So, here's a fix:

CloudRedirect 2.2.5 (WIP number, a forthcoming update that should be public in ~48 hours) exports `CR_InstallVtableHooks()` which hooks at the vtable level of `CClientUnifiedServiceTransport`, the RPC dispatch layer. Clients that need that can opt-in. Solves the problem entirely.

Also included in this PR: support for the Stats Sync (Achievements/Playtime) API

So, yeah. As a bonus, I am adding support for CloudRedirect's stats sync feature (CR 2.2.5+). I am doing this because I needed to do it in order to _test_ this functionality for CR 2.2.5. **I do not want this PR to be perceived as me preferencing OST over any other Steam unlock solution.** This specific patch (the new features) exists for testing purposes. Rather than making it and throwing it away, I am contributing it in good faith. Fixing the issues with the previous PR exists so that I do not get slammed with issue reports 😄 

- `CR_EnableStatsSync(true, true)` - registers interest in stats events
- `NotifyAppRunning(appId, running)` - fired when tracked app starts/stops
- `NotifyStatsStored(appId)` - fired on `k_EMsgClientStoreUserStats2` (5466)

**These are optional exports**.  No third party client is required to add support for the Stat Sync system in order to support core Cloud Save functionality. The purpose of the API is to allow Steam unlock solutions to opt in to specific features. I am including them under the assumption that opting in is acceptable. The actual sync behavior is off by default and is controlled by CR's UI.

Speaking of defaults,  is there room to revisit the CR enable/disable behavior? Not sure that controlling it by enabling something in the OST config makes a whole lot of sense. I can't think of a better way, but it means that the CR UI alone is not enough to deploy CR successfully. 

All of this stuff works against a pre-release build of CR that I can share if you want it. It does degrade to the old (broken, IMO) behavior in the Peron patch. 