### PR TITLE
feat: recursively load .lua files under config/lua

### DIFF
--- a/src/OSTPlatform/Windows/DirectoryWatch.cpp
+++ b/src/OSTPlatform/Windows/DirectoryWatch.cpp
@@ -98,7 +98,7 @@ bool Watch::IssueRead() {
             impl_->dir.get(),
             impl_->buffer.data(),
             static_cast<DWORD>(impl_->buffer.size()),
-            FALSE,
+            TRUE,
             FILE_NOTIFY_CHANGE_FILE_NAME | FILE_NOTIFY_CHANGE_LAST_WRITE,
             &dummy,
             &impl_->overlapped,

--- a/src/Utils/Config/LuaConfig.cpp
+++ b/src/Utils/Config/LuaConfig.cpp
@@ -689,11 +689,21 @@ namespace LuaConfig{
         if (!std::filesystem::exists(directory, ec) || !std::filesystem::is_directory(directory, ec))
             return files;
 
-        for (const auto& entry : std::filesystem::directory_iterator(directory, ec)) {
-            if (ec) break;
-            if (!entry.is_regular_file()) continue;
-            if (entry.path().extension() != ".lua") continue;
-            files.push_back(entry.path().string());
+        std::vector<std::filesystem::path> pending = { std::filesystem::path(directory) };
+        while (!pending.empty()) {
+            std::filesystem::path current = pending.back();
+            pending.pop_back();
+
+            std::error_code dec;
+            for (const auto& entry : std::filesystem::directory_iterator(current, dec)) {
+                if (dec) break;
+                std::error_code fec;
+                if (entry.is_directory(fec)) {
+                    pending.push_back(entry.path());
+                } else if (entry.is_regular_file(fec) && entry.path().extension() == ".lua") {
+                    files.push_back(entry.path().string());
+                }
+            }
         }
         return files;
     }


### PR DESCRIPTION
## What
Support organizing Lua scripts in subdirectories under the Lua directory, so users can keep one file per game (or any other layout) instead of being forced to flatten everything into the root.

## Changes
- CollectLuaFiles (LuaConfig.cpp) now walks subdirectories recursively (manual stack-based traversal with error_code, so unreadable dirs are skipped safely). Only .lua regular files are collected, everything else unchanged.
- Watch::IssueRead (DirectoryWatch.cpp): ReadDirectoryChangesW now uses WatchSubtree=TRUE, so file changes in subdirectories trigger hot reload too.

## Behavior preserved
- Per-file tracking, mtime-based purchase time, manifest override precedence (later-parsed file wins), debounce, and the [lua] paths mechanism are all unchanged.
- Existing flat files in the Lua dir keep working.

## Verification
- Subdirectory lua files are loaded (depot keys + appids registered at startup).
- Adding/removing a .lua file inside a subdirectory triggers hot reload without restart (verified in logs: inserted AppId / emoved AppId).