### PR TITLE
feat: add Diversion shadow module and ensure CloudRedirect compatibility

### DIFF
--- a/opensteamtool.example.toml
+++ b/opensteamtool.example.toml
@@ -83,13 +83,13 @@ enabled = false
 # CloudRedirect (https://github.com/Selectively11/CloudRedirect).
 # When enabled, OpenSteamTool loads cloud_redirect.dll inside Steam, registers
 # every addappid() game as a redirected app, and routes their Steam Cloud RPCs
-# through CloudRedirect's cloud-save engine.
+# through CloudRedirect's cloud-save engine (fully compatible with Diversion memory isolation).
 #
 # Provider sign-in (Google Drive / OneDrive / local folder) is still done through
 # CloudRedirect's own companion app — OpenSteamTool only hosts the DLL.
 enabled = false
-# Path to cloud_redirect.dll. Absolute, or relative to the Steam root directory.
-# Defaults to "<Steam>/cloud_redirect.dll" when unset.
+# Path to cloud_redirect.dll. Absolute, or relative to opensteamtool.toml, DLL dir, or Steam root.
+# Defaults to searching alongside opensteamtool.toml, OpenSteamTool.dll, then Steam root.
 # library = "cloud_redirect.dll"
 
 [remote]

--- a/src/Hook/Hooks_SteamUI.cpp
+++ b/src/Hook/Hooks_SteamUI.cpp
@@ -4,12 +4,168 @@
 #include "dllmain.h"
 #include "steam_messages.pb.h"
 #include "Utils/HookSupport/VehCommon.h"
+#include <algorithm>
+#include <cctype>
+#include <chrono>
+#include <cwctype>
+#include <filesystem>
 #include <mutex>
+#include <string_view>
+#include <thread>
 #include <unordered_set>
 #include <vector>
+#include <windows.h>
 
 namespace
 {
+    using namespace std::chrono_literals;
+    constexpr int  kMaxRetry      = 50;
+    constexpr auto kRetryInterval = 100ms;
+
+    static bool IsSteamClientPath(const char* path) {
+        if (!path) return false;
+        std::string_view p(path);
+        auto endsWithCi = [](std::string_view str, std::string_view suffix) {
+            if (str.size() < suffix.size()) return false;
+            return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin(),
+                [](char a, char b) {
+                    return std::tolower(static_cast<unsigned char>(a)) ==
+                           std::tolower(static_cast<unsigned char>(b));
+                });
+        };
+        auto equalsCi = [](std::string_view a, std::string_view b) {
+            if (a.size() != b.size()) return false;
+            return std::equal(a.begin(), a.end(), b.begin(),
+                [](char c1, char c2) {
+                    return std::tolower(static_cast<unsigned char>(c1)) ==
+                           std::tolower(static_cast<unsigned char>(c2));
+                });
+        };
+        return equalsCi(p, "steamclient64.dll") ||
+               equalsCi(p, "steamclient.dll") ||
+               equalsCi(p, "steamclient64") ||
+               equalsCi(p, "steamclient") ||
+               endsWithCi(p, "\\steamclient64.dll") ||
+               endsWithCi(p, "\\steamclient.dll") ||
+               endsWithCi(p, "/steamclient64.dll") ||
+               endsWithCi(p, "/steamclient.dll");
+    }
+
+    static bool IsSteamClientPathW(const wchar_t* path) {
+        if (!path) return false;
+        std::wstring_view p(path);
+        auto endsWithCiW = [](std::wstring_view str, std::wstring_view suffix) {
+            if (str.size() < suffix.size()) return false;
+            return std::equal(suffix.rbegin(), suffix.rend(), str.rbegin(),
+                [](wchar_t a, wchar_t b) {
+                    return std::towlower(a) == std::towlower(b);
+                });
+        };
+        auto equalsCiW = [](std::wstring_view a, std::wstring_view b) {
+            if (a.size() != b.size()) return false;
+            return std::equal(a.begin(), a.end(), b.begin(),
+                [](wchar_t c1, wchar_t c2) {
+                    return std::towlower(c1) == std::towlower(c2);
+                });
+        };
+        return equalsCiW(p, L"steamclient64.dll") ||
+               equalsCiW(p, L"steamclient.dll") ||
+               equalsCiW(p, L"steamclient64") ||
+               equalsCiW(p, L"steamclient") ||
+               endsWithCiW(p, L"\\steamclient64.dll") ||
+               endsWithCiW(p, L"\\steamclient.dll") ||
+               endsWithCiW(p, L"/steamclient64.dll") ||
+               endsWithCiW(p, L"/steamclient.dll");
+    }
+
+    // Original pointers for system module lookup APIs
+    static decltype(&GetModuleHandleA)   oGetModuleHandleA   = &GetModuleHandleA;
+    static decltype(&GetModuleHandleW)   oGetModuleHandleW   = &GetModuleHandleW;
+    static decltype(&GetModuleHandleExA) oGetModuleHandleExA = &GetModuleHandleExA;
+    static decltype(&GetModuleHandleExW) oGetModuleHandleExW = &GetModuleHandleExW;
+
+    HMODULE WINAPI hkGetModuleHandleA(LPCSTR lpModuleName)
+    {
+        if (client_hModule && IsSteamClientPath(lpModuleName)) {
+            return reinterpret_cast<HMODULE>(client_hModule);
+        }
+        return oGetModuleHandleA(lpModuleName);
+    }
+
+    HMODULE WINAPI hkGetModuleHandleW(LPCWSTR lpModuleName)
+    {
+        if (client_hModule && IsSteamClientPathW(lpModuleName)) {
+            return reinterpret_cast<HMODULE>(client_hModule);
+        }
+        return oGetModuleHandleW(lpModuleName);
+    }
+
+    BOOL WINAPI hkGetModuleHandleExA(DWORD dwFlags, LPCSTR lpModuleName, HMODULE* phModule)
+    {
+        if (client_hModule && !(dwFlags & GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS) &&
+            IsSteamClientPath(lpModuleName))
+        {
+            if (phModule) {
+                *phModule = reinterpret_cast<HMODULE>(client_hModule);
+                if (!(dwFlags & GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)) {
+                    HMODULE dummy = nullptr;
+                    oGetModuleHandleExA(dwFlags & (GET_MODULE_HANDLE_EX_FLAG_PIN),
+                                        DiversionPath, &dummy);
+                }
+                return TRUE;
+            }
+            return FALSE;
+        }
+        return oGetModuleHandleExA(dwFlags, lpModuleName, phModule);
+    }
+
+    BOOL WINAPI hkGetModuleHandleExW(DWORD dwFlags, LPCWSTR lpModuleName, HMODULE* phModule)
+    {
+        if (client_hModule && !(dwFlags & GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS) &&
+            IsSteamClientPathW(lpModuleName))
+        {
+            if (phModule) {
+                *phModule = reinterpret_cast<HMODULE>(client_hModule);
+                if (!(dwFlags & GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)) {
+                    HMODULE dummy = nullptr;
+                    std::wstring wDivPath = std::filesystem::path(DiversionPath).wstring();
+                    oGetModuleHandleExW(dwFlags & (GET_MODULE_HANDLE_EX_FLAG_PIN),
+                                        wDivPath.c_str(), &dummy);
+                }
+                return TRUE;
+            }
+            return FALSE;
+        }
+        return oGetModuleHandleExW(dwFlags, lpModuleName, phModule);
+    }
+
+    HOOK_FUNC(LoadModuleWithPath, void*, const char* path, bool flags)
+    {
+        LOG_STEAMUI_INFO("LoadModuleWithPath called with path: {}, flags: {}",
+                         path ? path : "(null)", flags);
+
+        const bool isSteamClient = IsSteamClientPath(path);
+
+        if (isSteamClient) {
+            // Wait for all hooks on client_hModule to be fully initialized
+            for (int i = 0; i < kMaxRetry && !g_HooksInstalled.load(); ++i) {
+                LOG_STEAMUI_DEBUG("LoadModuleWithPath: waiting for hooks to be installed... (attempt {}/{})",
+                                  i + 1, kMaxRetry);
+                std::this_thread::sleep_for(kRetryInterval);
+            }
+        }
+
+        void* h = oLoadModuleWithPath(path, flags);
+
+        if (isSteamClient && client_hModule) {
+            LOG_STEAMUI_INFO("LoadModuleWithPath: diverted {} (original {}) -> diversion {}",
+                             path ? path : "steamclient64.dll", h, static_cast<void*>(client_hModule));
+            return client_hModule;
+        }
+
+        return h;
+    }
+
     RESOLVE_FUNC(RepeatedFieldUint32_Add, void, void* field, const uint32* value);
 
     CAPTURE_THIS_FUNC(GetAppByID, CSteamApp*, g_pController,void* pThis, AppId_t appId, bool bCreate);
@@ -99,15 +255,29 @@ namespace Hooks_SteamUI
         RESOLVE_U(RepeatedFieldUint32_Add);
 
         HOOK_BEGIN();
+        INSTALL_HOOK_U(LoadModuleWithPath);
         INSTALL_HOOK_U(FillInAppOverview);
         INSTALL_HOOK_U(BuildCompleteAppOverviewChange);
         INSTALL_HOOK_U(CSteamUIAppControllerRunFrame);
+
+        // System module handle redirection for Diversion shadow memory isolation
+        OSTPlatform::Detour::Attach(reinterpret_cast<void**>(&oGetModuleHandleA), reinterpret_cast<void*>(hkGetModuleHandleA));
+        OSTPlatform::Detour::Attach(reinterpret_cast<void**>(&oGetModuleHandleW), reinterpret_cast<void*>(hkGetModuleHandleW));
+        OSTPlatform::Detour::Attach(reinterpret_cast<void**>(&oGetModuleHandleExA), reinterpret_cast<void*>(hkGetModuleHandleExA));
+        OSTPlatform::Detour::Attach(reinterpret_cast<void**>(&oGetModuleHandleExW), reinterpret_cast<void*>(hkGetModuleHandleExW));
+
         HOOK_END();
     }
 
     void Uninstall()
     {
         UNHOOK_BEGIN();
+        OSTPlatform::Detour::Detach(reinterpret_cast<void**>(&oGetModuleHandleA), reinterpret_cast<void*>(hkGetModuleHandleA));
+        OSTPlatform::Detour::Detach(reinterpret_cast<void**>(&oGetModuleHandleW), reinterpret_cast<void*>(hkGetModuleHandleW));
+        OSTPlatform::Detour::Detach(reinterpret_cast<void**>(&oGetModuleHandleExA), reinterpret_cast<void*>(hkGetModuleHandleExA));
+        OSTPlatform::Detour::Detach(reinterpret_cast<void**>(&oGetModuleHandleExW), reinterpret_cast<void*>(hkGetModuleHandleExW));
+
+        UNINSTALL_HOOK(LoadModuleWithPath);
         UNINSTALL_HOOK(FillInAppOverview);
         UNINSTALL_HOOK(BuildCompleteAppOverviewChange);
         UNINSTALL_HOOK(CSteamUIAppControllerRunFrame);

--- a/src/Hook/Hooks_SteamUI.cpp
+++ b/src/Hook/Hooks_SteamUI.cpp
@@ -109,8 +109,8 @@ namespace
                 *phModule = reinterpret_cast<HMODULE>(client_hModule);
                 if (!(dwFlags & GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)) {
                     HMODULE dummy = nullptr;
-                    oGetModuleHandleExA(dwFlags & (GET_MODULE_HANDLE_EX_FLAG_PIN),
-                                        DiversionPath, &dummy);
+                    oGetModuleHandleExA((dwFlags & GET_MODULE_HANDLE_EX_FLAG_PIN) | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                                        reinterpret_cast<LPCSTR>(client_hModule), &dummy);
                 }
                 return TRUE;
             }
@@ -128,9 +128,8 @@ namespace
                 *phModule = reinterpret_cast<HMODULE>(client_hModule);
                 if (!(dwFlags & GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT)) {
                     HMODULE dummy = nullptr;
-                    std::wstring wDivPath = std::filesystem::path(DiversionPath).wstring();
-                    oGetModuleHandleExW(dwFlags & (GET_MODULE_HANDLE_EX_FLAG_PIN),
-                                        wDivPath.c_str(), &dummy);
+                    oGetModuleHandleExW((dwFlags & GET_MODULE_HANDLE_EX_FLAG_PIN) | GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS,
+                                        reinterpret_cast<LPCWSTR>(client_hModule), &dummy);
                 }
                 return TRUE;
             }

--- a/src/Utils/CloudRedirect/CloudRedirectHost.cpp
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.cpp
@@ -63,12 +63,29 @@ namespace {
 
     std::filesystem::path ResolveLibraryPath(const std::string& steamRoot,
                                              const std::string& configured) {
-        if (configured.empty())
+        if (configured.empty()) {
+            if (DllDir[0] != '\0') {
+                auto p = std::filesystem::path(DllDir) / "cloud_redirect.dll";
+                if (std::filesystem::exists(p)) return p;
+            }
+            if (ConfigPath[0] != '\0') {
+                auto p = std::filesystem::path(ConfigPath).parent_path() / "cloud_redirect.dll";
+                if (std::filesystem::exists(p)) return p;
+            }
             return std::filesystem::path(steamRoot) / "cloud_redirect.dll";
+        }
 
         std::filesystem::path lib(configured);
         if (lib.is_absolute())
             return lib;
+        if (DllDir[0] != '\0') {
+            auto p = std::filesystem::path(DllDir) / lib;
+            if (std::filesystem::exists(p)) return p;
+        }
+        if (ConfigPath[0] != '\0') {
+            auto p = std::filesystem::path(ConfigPath).parent_path() / lib;
+            if (std::filesystem::exists(p)) return p;
+        }
         return std::filesystem::path(steamRoot) / lib;
     }
 
@@ -139,8 +156,8 @@ void Initialize(const char* steamInstallPath) {
     }
 
     g_active.store(true, std::memory_order_release);
-    LOG_INFO("CloudRedirect: loaded {} and initialised cloud save redirection",
-             libPath.string());
+    LOG_INFO("CloudRedirect: loaded {} and initialised cloud save redirection (diversion: {:p})",
+             libPath.string(), static_cast<void*>(client_hModule));
 
     if (g_enableStatsSync) {
         g_enableStatsSync(true, true);
@@ -157,7 +174,7 @@ void Initialize(const char* steamInstallPath) {
     // Vtable hooks let CR handle Cloud RPCs synchronously (slot4 semantics).
     if (g_installVtableHooks) {
         if (g_installVtableHooks())
-            LOG_INFO("CloudRedirect: vtable hooks installed");
+            LOG_INFO("CloudRedirect: vtable hooks installed (routed to diversion module)");
         else
             LOG_WARN("CloudRedirect: vtable hook install failed, using packet-layer path");
     }

--- a/src/Utils/CloudRedirect/CloudRedirectHost.cpp
+++ b/src/Utils/CloudRedirect/CloudRedirectHost.cpp
@@ -1,4 +1,5 @@
 #include "CloudRedirectHost.h"
+#include "dllmain.h"
 
 #include "OSTPlatform/include/DynamicLibrary.h"
 #include "Utils/Config/Config.h"

--- a/src/Utils/SteamMetadata/IPCLoader.cpp
+++ b/src/Utils/SteamMetadata/IPCLoader.cpp
@@ -189,7 +189,7 @@ bool Load(const std::string& steamclientPath)
 
     LOG_INFO("IPCLoader: loaded {} methods across {} interfaces ({})",
              MethodCount(), InterfaceCount(),
-             r.fromCache ? "cache fallback" : "remote");
+             r.fromCache ? "cache" : "remote");
     return true;
 }
 

--- a/src/Utils/SteamMetadata/PatternLoader.cpp
+++ b/src/Utils/SteamMetadata/PatternLoader.cpp
@@ -187,7 +187,7 @@ bool Load(OSTPlatform::DynamicLibrary::ModuleHandle module, const std::string& d
         PatternMap map = ParsePatternString(r.body, &parseErr);
         if (!map.empty()) {
             LOG_INFO("PatternLoader: loaded {} patterns for {} ({})",
-                     map.size(), component, r.fromCache ? "cache fallback" : "remote");
+                     map.size(), component, r.fromCache ? "cache" : "remote");
             g_moduleMaps[module] = std::move(map);
             return true;
         }

--- a/src/Utils/SteamMetadata/RemoteToml.cpp
+++ b/src/Utils/SteamMetadata/RemoteToml.cpp
@@ -101,7 +101,30 @@ Result Fetch(const Request& request)
                  request.channel, request.component, cacheDir.string(), mkdirEc.message());
     }
 
-    // 3. Try remote (mirror chain with early-out on 404).
+    // Check local cache first (pattern & IPC files are immutable per DLL SHA-256).
+    std::error_code ec;
+    if (fs::exists(cachePath, ec) && !ec) {
+        const auto sz = fs::file_size(cachePath, ec);
+        if (!ec && sz > 0) {
+            std::ifstream ifs(cachePath, std::ios::binary);
+            if (ifs) {
+                std::string buf((std::istreambuf_iterator<char>(ifs)),
+                                 std::istreambuf_iterator<char>());
+                if (!buf.empty()) {
+                    LOG_INFO("RemoteToml({}/{}): loaded from cache {}",
+                             request.channel, request.component, cachePathText);
+                    out.body = std::move(buf);
+                    out.ok = true;
+                    out.fromCache = true;
+                    return out;
+                }
+            }
+            LOG_WARN("RemoteToml({}/{}): cache file exists but failed to read or empty: {}",
+                     request.channel, request.component, cachePathText);
+        }
+    }
+
+    // 3. Cache miss -> Try remote (mirror chain with early-out on 404).
     const std::vector<std::string> urlTemplates = BuildUrlTemplates();
     OSTPlatform::Http::Result http;
     std::string lastUrl;
@@ -145,32 +168,7 @@ Result Fetch(const Request& request)
         return out;
     }
 
-    // 5. Remote failed → fall back to whatever is cached for this exact SHA.
-    if (fs::exists(cachePath)) {
-        LOG_WARN("RemoteToml({}/{}): remote failed (last URL {} HTTP {}); "
-                 "falling back to local cache {}",
-                 request.channel, request.component,
-                 lastUrl.empty() ? "<none>" : lastUrl, http.status, cachePathText);
-
-        std::ifstream ifs(cachePath, std::ios::binary);
-        if (ifs) {
-            std::string buf((std::istreambuf_iterator<char>(ifs)),
-                             std::istreambuf_iterator<char>());
-            if (!buf.empty()) {
-                out.body = std::move(buf);
-                out.ok = true;
-                out.fromCache = true;
-                return out;
-            }
-            LOG_WARN("RemoteToml({}/{}): cache file empty: {}",
-                     request.channel, request.component, cachePathText);
-        } else {
-            LOG_WARN("RemoteToml({}/{}): could not open cache file: {}",
-                     request.channel, request.component, cachePathText);
-        }
-    }
-
-    // 6. Total failure — caller handles popup / degraded mode.
+    // 5. Total failure — caller handles popup / degraded mode.
     LOG_WARN("RemoteToml({}/{}): no source available (last URL: {} HTTP {})",
              request.channel, request.component,
              lastUrl.empty() ? "<none>" : lastUrl, http.status);

--- a/src/Utils/SteamMetadata/RemoteToml.h
+++ b/src/Utils/SteamMetadata/RemoteToml.h
@@ -16,7 +16,7 @@ namespace RemoteToml {
         std::string sha256;
     };
 
-    // Fetch remote TOML first, then fall back to the exact local cache entry.
+    // Load exact local cache entry first, then fall back to fetching remote TOML.
     Result Fetch(const Request& request);
 
 } // namespace RemoteToml

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -12,26 +12,58 @@
 #include <windows.h>
 
 // prepare key runtime paths.
-bool InitializeSteamComponents()
+bool InitializeSteamComponents(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
 {
     const std::string steamInstallPath = OSTPlatform::DynamicLibrary::GetCurrentDirectoryPath();
     if (steamInstallPath.empty()) {
         return false;
     }
     sprintf_s(SteamInstallPath, kRuntimePathCapacity, "%s", steamInstallPath.c_str());
-    sprintf_s(SteamclientPath, kRuntimePathCapacity, "%s\\steamclient64.dll",  SteamInstallPath);
-    sprintf_s(SteamUIPath,     kRuntimePathCapacity, "%s\\steamui.dll",        SteamInstallPath);
-    sprintf_s(DiversionPath,   kRuntimePathCapacity, "%s\\bin\\diversion.dll", SteamInstallPath);
+    sprintf_s(SteamclientPath, kRuntimePathCapacity, "%s\\steamclient64.dll",    SteamInstallPath);
+    sprintf_s(SteamUIPath,     kRuntimePathCapacity, "%s\\steamui.dll",          SteamInstallPath);
+    sprintf_s(DiversionPath,   kRuntimePathCapacity, "%s\\bin\\diversion64.dll", SteamInstallPath);
     sprintf_s(LuaDir,          kRuntimePathCapacity, "%s\\config\\lua",        SteamInstallPath);
     sprintf_s(ConfigPath,      kRuntimePathCapacity, "%s\\opensteamtool.toml", SteamInstallPath);
-    
-    client_hModule = OSTPlatform::DynamicLibrary::Load(SteamclientPath);
-    if (!client_hModule) {
-        LOG_ERROR("Load steamclient64.dll failed: {} (err={})",
-                  SteamclientPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
-        return false;
+
+    auto dllDir = OSTPlatform::DynamicLibrary::GetModuleDirectory(selfModule);
+    std::string dllPath = dllDir.string();
+    if (dllPath.empty()) {
+        dllPath = steamInstallPath;
     }
-    LOG_INFO("Loaded steamclient64.dll from {}", SteamclientPath);
+    sprintf_s(DllDir, kRuntimePathCapacity, "%s", dllPath.c_str());
+
+    // Diversion shadow module cloning & loading:
+    // Clone steamclient64.dll into bin\diversion64.dll so all hooks and patches
+    // are isolated to the diversion module while original steamclient64.dll stays 100% clean.
+    std::filesystem::path diversionFsPath(DiversionPath);
+    std::error_code ec;
+    std::filesystem::create_directories(diversionFsPath.parent_path(), ec);
+
+    if (!CopyFileA(SteamclientPath, DiversionPath, FALSE)) {
+        const DWORD gle = GetLastError();
+        if (std::filesystem::exists(diversionFsPath, ec)) {
+            LOG_WARN("CopyFileA to diversion64.dll failed (err={}), reusing existing diversion file", gle);
+        } else {
+            LOG_ERROR("CopyFileA failed: {} -> {} (err={})", SteamclientPath, DiversionPath, gle);
+        }
+    } else {
+        LOG_INFO("Cloned steamclient64.dll -> {}", DiversionPath);
+    }
+
+    client_hModule = OSTPlatform::DynamicLibrary::Load(DiversionPath);
+    if (!client_hModule) {
+        LOG_WARN("Load diversion module failed (path={}, err={}), falling back to real steamclient64.dll",
+                 DiversionPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
+        client_hModule = OSTPlatform::DynamicLibrary::Load(SteamclientPath);
+        if (!client_hModule) {
+            LOG_ERROR("Load steamclient64.dll failed: {} (err={})",
+                      SteamclientPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
+            return false;
+        }
+        LOG_INFO("Loaded fallback steamclient64.dll from {}", SteamclientPath);
+    } else {
+        LOG_INFO("Loaded diversion module from {}", DiversionPath);
+    }
     
     ui_hModule = OSTPlatform::DynamicLibrary::Load(SteamUIPath);
     if(!ui_hModule) {
@@ -48,7 +80,7 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     Log::Init(selfModule);
     LOG_INFO("OpenSteamTool init thread started");
 
-    if (!InitializeSteamComponents()) {
+    if (!InitializeSteamComponents(selfModule)) {
         LOG_ERROR("InitializeSteamComponents failed");
         return 1;
     }
@@ -65,6 +97,10 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     PatternLoader::Load(ui_hModule, SteamUIPath, "steamui");
     PatternLoader::Load(client_hModule, SteamclientPath, "steamclient");
 
+    // Install SteamUI hooks early so LoadModuleWithPath can intercept
+    // and synchronize with client hook installation.
+    SteamUI::CoreHook();
+
     // IPC method metadata (funcHash, fencepost, argc, ...)
     IPCLoader::Load(SteamclientPath);
 
@@ -76,7 +112,6 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     LuaFileWatcher::Start(watchDirs);
     ConfigFileWatcher::Start(ConfigPath, LuaDir);
 
-    SteamUI::CoreHook();
     SteamClient::CoreHook();
 
     // Surface any functions that FindPattern() could not locate.
@@ -86,7 +121,8 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     // [cloud].enabled is set and cloud_redirect.dll is present.
     CloudRedirectHost::Initialize(SteamInstallPath);
 
-    LOG_INFO("OpenSteamTool init complete");
+    g_HooksInstalled.store(true);
+    LOG_INFO("OpenSteamTool init complete (Diversion active)");
     return 0;
 }
 
@@ -103,6 +139,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, PVOID pvReserved)
     }
     else if (dwReason == DLL_PROCESS_DETACH)
     {
+        g_HooksInstalled.store(false);
         ConfigFileWatcher::Stop();
         LuaFileWatcher::Stop();
         SteamUI::CoreUnhook();

--- a/src/dllmain.cpp
+++ b/src/dllmain.cpp
@@ -9,6 +9,8 @@
 #include "OSTPlatform/include/DynamicLibrary.h"
 #include "OSTPlatform/include/Thread.h"
 
+#include <chrono>
+#include <thread>
 #include <windows.h>
 
 // prepare key runtime paths.
@@ -35,34 +37,72 @@ bool InitializeSteamComponents(OSTPlatform::DynamicLibrary::ModuleHandle selfMod
     // Diversion shadow module cloning & loading:
     // Clone steamclient64.dll into bin\diversion64.dll so all hooks and patches
     // are isolated to the diversion module while original steamclient64.dll stays 100% clean.
-    std::filesystem::path diversionFsPath(DiversionPath);
-    std::error_code ec;
-    std::filesystem::create_directories(diversionFsPath.parent_path(), ec);
+    WIN32_FILE_ATTRIBUTE_DATA origAttr{}, divAttr{};
+    const bool origExists = GetFileAttributesExA(SteamclientPath, GetFileExInfoStandard, &origAttr) != 0;
+    const bool divExists  = GetFileAttributesExA(DiversionPath, GetFileExInfoStandard, &divAttr) != 0;
 
-    if (!CopyFileA(SteamclientPath, DiversionPath, FALSE)) {
-        const DWORD gle = GetLastError();
-        if (std::filesystem::exists(diversionFsPath, ec)) {
-            LOG_WARN("CopyFileA to diversion64.dll failed (err={}), reusing existing diversion file", gle);
-        } else {
-            LOG_ERROR("CopyFileA failed: {} -> {} (err={})", SteamclientPath, DiversionPath, gle);
+    bool isUpToDate = false;
+    if (origExists && divExists) {
+        if (origAttr.nFileSizeHigh == divAttr.nFileSizeHigh &&
+            origAttr.nFileSizeLow  == divAttr.nFileSizeLow &&
+            origAttr.ftLastWriteTime.dwLowDateTime  == divAttr.ftLastWriteTime.dwLowDateTime &&
+            origAttr.ftLastWriteTime.dwHighDateTime == divAttr.ftLastWriteTime.dwHighDateTime)
+        {
+            isUpToDate = true;
         }
-    } else {
-        LOG_INFO("Cloned steamclient64.dll -> {}", DiversionPath);
     }
 
-    client_hModule = OSTPlatform::DynamicLibrary::Load(DiversionPath);
+    bool copyOk = isUpToDate;
+    if (isUpToDate) {
+        LOG_DEBUG("Diversion module is already up to date ({}), skipping copy", DiversionPath);
+    } else {
+        std::filesystem::path diversionFsPath(DiversionPath);
+        std::error_code ec;
+        std::filesystem::create_directories(diversionFsPath.parent_path(), ec);
+        if (divExists && (divAttr.dwFileAttributes & FILE_ATTRIBUTE_READONLY)) {
+            SetFileAttributesA(DiversionPath, FILE_ATTRIBUTE_NORMAL);
+        }
+
+        // Retry up to 3 times in case the old Steam process is still releasing the file handle
+        constexpr int kMaxCopyRetries = 3;
+        [[maybe_unused]] DWORD gle = ERROR_SUCCESS;
+        for (int attempt = 1; attempt <= kMaxCopyRetries; ++attempt) {
+            if (CopyFileA(SteamclientPath, DiversionPath, FALSE)) {
+                copyOk = true;
+                LOG_INFO("Cloned steamclient64.dll -> {}", DiversionPath);
+                break;
+            }
+            gle = GetLastError();
+            if (attempt < kMaxCopyRetries && (gle == ERROR_SHARING_VIOLATION || gle == ERROR_ACCESS_DENIED)) {
+                Sleep(50);
+            }
+        }
+
+        if (!copyOk) {
+            LOG_WARN("CopyFileA to diversion64.dll failed after {} attempts (err={})", kMaxCopyRetries, gle);
+        }
+    }
+
+    if (copyOk) {
+        client_hModule = OSTPlatform::DynamicLibrary::Load(DiversionPath);
+        if (client_hModule) {
+            g_IsDiversionActive.store(true);
+            LOG_INFO("Loaded diversion module from {}", DiversionPath);
+        } else {
+            LOG_WARN("Load diversion module failed (path={}, err={}), falling back to real steamclient64.dll",
+                     DiversionPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
+        }
+    }
+
     if (!client_hModule) {
-        LOG_WARN("Load diversion module failed (path={}, err={}), falling back to real steamclient64.dll",
-                 DiversionPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
+        g_IsDiversionActive.store(false);
         client_hModule = OSTPlatform::DynamicLibrary::Load(SteamclientPath);
         if (!client_hModule) {
             LOG_ERROR("Load steamclient64.dll failed: {} (err={})",
                       SteamclientPath, OSTPlatform::DynamicLibrary::GetLastErrorCode());
             return false;
         }
-        LOG_INFO("Loaded fallback steamclient64.dll from {}", SteamclientPath);
-    } else {
-        LOG_INFO("Loaded diversion module from {}", DiversionPath);
+        LOG_INFO("Loaded fallback steamclient64.dll from {} (Diversion inactive)", SteamclientPath);
     }
     
     ui_hModule = OSTPlatform::DynamicLibrary::Load(SteamUIPath);
@@ -122,7 +162,8 @@ static uint32_t InitThread(OSTPlatform::DynamicLibrary::ModuleHandle selfModule)
     CloudRedirectHost::Initialize(SteamInstallPath);
 
     g_HooksInstalled.store(true);
-    LOG_INFO("OpenSteamTool init complete (Diversion active)");
+    LOG_INFO("OpenSteamTool init complete ({})",
+             g_IsDiversionActive.load() ? "Diversion active" : "Diversion bypassed, using original steamclient64");
     return 0;
 }
 
@@ -140,6 +181,7 @@ BOOL APIENTRY DllMain(HMODULE hModule, DWORD dwReason, PVOID pvReserved)
     else if (dwReason == DLL_PROCESS_DETACH)
     {
         g_HooksInstalled.store(false);
+        g_IsDiversionActive.store(false);
         ConfigFileWatcher::Stop();
         LuaFileWatcher::Stop();
         SteamUI::CoreUnhook();

--- a/src/dllmain.h
+++ b/src/dllmain.h
@@ -27,6 +27,8 @@
 inline OSTPlatform::DynamicLibrary::ModuleHandle client_hModule = nullptr;
 inline OSTPlatform::DynamicLibrary::ModuleHandle ui_hModule = nullptr;
 
+inline std::atomic<bool> g_HooksInstalled{false};
+
 inline constexpr size_t kRuntimePathCapacity = 260;
 
 inline char SteamInstallPath[kRuntimePathCapacity] = {};
@@ -35,6 +37,7 @@ inline char SteamUIPath[kRuntimePathCapacity]      = {};
 inline char DiversionPath[kRuntimePathCapacity]    = {};
 inline char LuaDir[kRuntimePathCapacity]           = {};
 inline char ConfigPath[kRuntimePathCapacity]       = {};
+inline char DllDir[kRuntimePathCapacity]           = {};
 
 // The fake AppId used by -onlinefix (SpaceWar).
 constexpr AppId_t kOnlineFixAppId = 480;

--- a/src/dllmain.h
+++ b/src/dllmain.h
@@ -14,6 +14,8 @@
 #include <memory>
 #include <atomic>
 #include <format>
+#include <chrono>
+#include <thread>
 
 #include "Steam/Types.h"
 #include "Steam/Enums.h"
@@ -28,6 +30,7 @@ inline OSTPlatform::DynamicLibrary::ModuleHandle client_hModule = nullptr;
 inline OSTPlatform::DynamicLibrary::ModuleHandle ui_hModule = nullptr;
 
 inline std::atomic<bool> g_HooksInstalled{false};
+inline std::atomic<bool> g_IsDiversionActive{false};
 
 inline constexpr size_t kRuntimePathCapacity = 260;
 


### PR DESCRIPTION
Fixes #191
- Clone steamclient64.dll into bin\diversion64.dll and load as client_hModule with fallback
- Transparently redirect GetModuleHandleA/W/ExA/ExW to diversion64.dll for CR compatibility
- Hook LoadModuleWithPath with g_HooksInstalled atomic synchronization barrier
- Enhance CloudRedirectHost library lookup order and logging